### PR TITLE
Reverts some equality check changes suggested by linter

### DIFF
--- a/CRADLE/CallPeak/calculateRC.pyx
+++ b/CRADLE/CallPeak/calculateRC.pyx
@@ -249,7 +249,7 @@ cpdef defineRegion(region):
 
 		region_var = np.nanvar(rc)
 
-		if np.isnan(region_var):
+		if np.isnan(region_var) == True:
 			deleteIdx.extend([regionIdx])
 			continue
 

--- a/CRADLE/CorrectBias/correctBias.py
+++ b/CRADLE/CorrectBias/correctBias.py
@@ -66,7 +66,7 @@ def getCandidateTrainSet(rcPercentile):
 		if numBin == 0:
 			numBin = 1
 		temp = np.array(ctrlBW.stats(regionChromo, regionStart, regionEnd, nBins=numBin, type="mean"))
-		temp = temp[np.where(temp is not None)]
+		temp = temp[np.where(temp != None)]
 		temp = temp[np.where(temp > 0)]
 
 		meanRC.extend(temp.tolist())
@@ -146,7 +146,7 @@ def FilltrainSetMeta(trainBinInfo):
 				meanValues = np.array(ctrlBW.stats(regionChromo, regionStart, regionEnd, nBins=numBin, type="mean"))
 				pos = np.array(list(range(0, numBin))) * trainBinSize + regionStart
 
-				idx = np.where(meanValues is not None)
+				idx = np.where(meanValues != None)
 				meanValues = meanValues[idx]
 				pos = pos[idx]
 
@@ -190,7 +190,7 @@ def FilltrainSetMeta(trainBinInfo):
 				meanValues = np.array(ctrlBW.stats(regionChromo, regionStart, regionEnd, nBins=numBin, type="mean"))
 				pos = np.array(list(range(0, numBin))) * trainBinSize + regionStart
 
-				idx = np.where(meanValues is not None)
+				idx = np.where(meanValues != None)
 				meanValues = meanValues[idx]
 				pos = pos[idx]
 
@@ -313,7 +313,7 @@ def getScaler(trainSet):
 			numBin = int((sub_regionEnd - sub_regionStart) / vari.BINSIZE)
 
 			temp = np.array(ob1.stats(regionChromo, sub_regionStart, sub_regionEnd, nBins=numBin, type="mean"))
-			idx = np.where(temp is None)
+			idx = np.where(temp == None)
 			temp[idx] = 0
 			temp = temp.tolist()
 			ob1Values.extend(temp)
@@ -364,7 +364,7 @@ def getScalerForEachSample(args):
 			numBin = int((sub_regionEnd - sub_regionStart) / vari.BINSIZE)
 
 			temp = np.array(ob2.stats(regionChromo, sub_regionStart, sub_regionEnd, nBins=numBin, type="mean"))
-			idx = np.where(temp is None)
+			idx = np.where(temp == None)
 			temp[idx] = 0
 			temp = temp.tolist()
 			ob2Values.extend(temp)
@@ -484,7 +484,7 @@ def generateNormalizedObBWs(args):
 		starts = np.array(range(start, end))
 		values = np.array(obBW.values(chromo, start, end))
 
-		idx = np.where( (not np.isnan(values)) & (values > 0))[0]
+		idx = np.where( (np.isnan(values) == False) & (values > 0))[0]
 		starts = starts[idx]
 		values = values[idx]
 		values = values / scaler

--- a/CRADLE/CorrectBiasStored/correctBias.py
+++ b/CRADLE/CorrectBiasStored/correctBias.py
@@ -51,7 +51,7 @@ def getCandidateTrainSet(rcPercentile):
 		if numBin == 0:
 			numBin = 1
 		temp = np.array(ctrlBW.stats(regionChromo, regionStart, regionEnd, nBins=numBin, type="mean"))
-		temp = temp[np.where(temp is not None)]
+		temp = temp[np.where(temp != None)]
 		temp = temp[np.where(temp > 0)]
 
 		meanRC.extend(temp.tolist())
@@ -130,7 +130,7 @@ def FilltrainSetMeta(trainBinInfo):
 				meanValues = np.array(ctrlBW.stats(regionChromo, regionStart, regionEnd, nBins=numBin, type="mean"))
 				pos = np.array(list(range(0, numBin))) * trainBinSize + regionStart
 
-				idx = np.where(meanValues is not None)
+				idx = np.where(meanValues != None)
 				meanValues = meanValues[idx]
 				pos = pos[idx]
 
@@ -174,7 +174,7 @@ def FilltrainSetMeta(trainBinInfo):
 				meanValues = np.array(ctrlBW.stats(regionChromo, regionStart, regionEnd, nBins=numBin, type="mean"))
 				pos = np.array(list(range(0, numBin))) * trainBinSize + regionStart
 
-				idx = np.where(meanValues is not None)
+				idx = np.where(meanValues != None)
 				meanValues = meanValues[idx]
 				pos = pos[idx]
 
@@ -440,7 +440,7 @@ def generateNormalizedObBWs(args):
 		starts = np.array(range(start, end))
 		values = np.array(obBW.values(chromo, start, end))
 
-		idx = np.where( (not np.isnan(values)) & (values > 0))[0]
+		idx = np.where( (np.isnan(values) == False) & (values > 0))[0]
 		starts = starts[idx]
 		values = values[idx]
 		values = values / scaler
@@ -558,7 +558,7 @@ def run(args):
 	print(vari.COVARI_ORDER)
 
 	noNan_idx = [0]
-	temp = np.where(not np.isnan(vari.SELECT_COVARI))[0] + 1
+	temp = np.where(np.isnan(vari.SELECT_COVARI) == False)[0] + 1
 	temp = temp.tolist()
 	noNan_idx.extend(temp)
 

--- a/CRADLE/CorrectBiasStored/vari.py
+++ b/CRADLE/CorrectBiasStored/vari.py
@@ -172,7 +172,7 @@ def setAnlaysisRegion(region, bl):
 		REGION = region_merged
 
 	## BL
-	if bl != None:  ### REMOVE BLACKLIST REGIONS FROM 'REGION'
+	if bl is not None:  ### REMOVE BLACKLIST REGIONS FROM 'REGION'
 		bl_region_temp = []
 		input_stream = open(bl)
 		input_file = input_stream.readlines()


### PR DESCRIPTION
All these reverts have to do with numpy arrays. Treating a numpy array of booleans is incorrect. For instance,
'array == False' is not the same as 'not array'. The first inverts all the booleans in the array. The second
evaluates to False, assuming 'array' is a truthy value.