### PR TITLE
Adds -rngSeed option to CorrectBias_stored

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -366,7 +366,7 @@ argument-naming-style=camelCase
 #argument-rgx=
 
 # Naming style matching correct attribute names.
-attr-naming-style=snake_case
+attr-naming-style=camelCase
 
 # Regular expression matching correct attribute names. Overrides attr-naming-
 # style.
@@ -439,7 +439,7 @@ inlinevar-naming-style=any
 #inlinevar-rgx=
 
 # Naming style matching correct method names.
-method-naming-style=snake_case
+method-naming-style=camelCase
 
 # Regular expression matching correct method names. Overrides method-naming-
 # style.

--- a/CRADLE/CorrectBiasStored/vari.py
+++ b/CRADLE/CorrectBiasStored/vari.py
@@ -13,6 +13,8 @@ def setGlobalVariables(args):
 	setFilterCriteria(args.mi)
 	setNumProcess(args.p)
 	setNormalization(args.norm, args.generateNormBW)
+	seed = setRngSeed(args.rngSeed)
+	writeRngSeed(seed, args.o)
 
 class StoredCovariates:
 	def __init__(self, biasTypes, directory):
@@ -398,3 +400,16 @@ def setNormalization(norm, generateNormBW):
 	if (not I_NORM) and I_GENERATE_NormBW:
 		print("ERROR: I_NOMR should be 'True' if I_GENERATE_NormBW is 'True'")
 		sys.exit()
+
+def setRngSeed(seed):
+	if seed is None:
+		seed = np.random.randint(0, 2**32 - 1)
+
+	np.random.seed(seed)
+	print(f"RNG Seed: {seed}")
+	return seed
+
+def writeRngSeed(seed, outputDir):
+	seedFileName = os.path.join(outputDir, "rngseed.txt")
+	with open(seedFileName, "w") as seedFile:
+		seedFile.write(f"{seed}\n")

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ cradle correctBias_stored -ctrlbw ctrl1.bw ctrl2.bw ctrl3.bw
      Whether normalization is needed for input bigwig files. Choose either 'True' or 'False'. default=True
   -  -generateNormBW <br />
      If you want to generate normalized observed bigwig files, type 'True' (only works when '-norm True'). If you don't want, type 'False'. default=False
+-  -rngSeed <br />
+     Set the seed value for the RNG. This enables repeatable runs. default=None
 
 ### 3) callPeak
 This command calls activated and repressed peaks with using corrected bigwig files as input. 

--- a/bin/cradle
+++ b/bin/cradle
@@ -84,6 +84,8 @@ def getArgs():
 
 	correctBiasStored_optional.add_argument('-generateNormBW', help="If you want to generate normalized observed bigwig files, type 'True' (only works when '-norm True'). If you don't want, type 'False'. default=False", default='False')
 
+	correctBiasStored_optional.add_argument('-rngSeed', type=int, help="Set seed value for the RNG. Enables repeatable runs.", default=None)
+
 
 	########### callPeak
 	callPeak_parser = subparsers.add_parser("callPeak", help="Correct peaks with corrected bigwig files")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = CRADLE
-version = 0.18.1
+version = 0.19.0
 description = Correct Read Counts and Analysis of Differently Expressed Regions
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
This option will eventually be added to CorrectBias as well.

To get repeatable runs I had to factor out the part of performRegression that called
np.random.choice because it's called from two different processes and the order would
be non-deterministic.

Additionally, I changed some variable names to be more descriptive, added a "label"
argument to performRegression so the output files of the process that finishes first
won't be clobbered by the output files of the process that finishes second.

Finally, I created some Cython classes to use instead of lists of 3-tuples for Training
Sets and Training Regions.