### PR TITLE
Fixes single bin fillTrainingSetMeta bug

### DIFF
--- a/CRADLE/correctbiasutils/__init__.py
+++ b/CRADLE/correctbiasutils/__init__.py
@@ -425,7 +425,7 @@ def fillTrainingSetMeta(downLimit, upLimit, trainingRegionNum, regions, ctrlBWNa
 		numBin = int( (regionEnd - regionStart) / TRAINING_BIN_SIZE )
 		if numBin == 0:
 			numBin = 1
-			meanValue = np.array(ctrlBW.stats(regionChromo, regionStart, regionEnd, nBins=numBin, type="mean"))
+			meanValue = ctrlBW.stats(regionChromo, regionStart, regionEnd, nBins=numBin, type="mean")[0]
 
 			if meanValue is None:
 				continue


### PR DESCRIPTION
When there is only a single bin the results of pyBigWig.stats was
being treated like a scalar value even though it was actually an
array with one value in it.

The fix here is just to get that value out of the array.
