### PR TITLE
Improves mean calculation

### DIFF
--- a/CRADLE/correctbiasutils/cython.pyx
+++ b/CRADLE/correctbiasutils/cython.pyx
@@ -5,6 +5,47 @@ import pyBigWig
 
 matplotlib.use('Agg')
 
+cpdef array_split(values, numBins, fillValue=np.nan):
+	"""Splits a numpy array of values into numBins "bins". If len(values) is not evenly
+	divisible by numBins the last bin gets the extra values.
+
+	Example:
+		array_split(np.arange(0, 16), 3) = [array(0, 1, 2, 3, 4), array(5, 6, 7, 8, 9), array(10, 11, 12, 13, 14, 15)]
+	"""
+
+	cdef float [:] valuesView
+	cdef int binCount
+	cdef int smallBinSize
+	cdef int valueCount
+	cdef int start
+	cdef int end
+	cdef int smallBinCount
+	cdef int i
+
+	binCount = numBins
+	if binCount < 1:
+		return values
+
+	valuesView = values
+	valueCount = len(valuesView)
+	smallBinSize = max(1, valueCount // binCount)
+	start = 0
+	end = smallBinSize
+	smallBinCount = binCount - 1
+	bins = [fillValue] * binCount
+
+	i = 0
+	while i < smallBinCount and end < valueCount:
+		bins[i] = valuesView[start:end]
+		start = end
+		end += smallBinSize
+		i += 1
+
+	if start < valueCount:
+		bins[i] = valuesView[start:]
+
+	return bins
+
 cpdef generateNormalizedObBWs(bwHeader, scaler, regions, observedBWName, normObBWName):
 	cdef int currStart
 	cdef int currEnd

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = CRADLE
-version = 0.22.0
+version = 0.23.0
 description = Correct Read Counts and Analysis of Differently Expressed Regions
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Using the pyBigWig stats method to calculate means is pretty slow. Additionally,
the "binning" algorithm is opaque and inscrutable.

This creates new methods for calculating the means and doing the binning which are currently
used for training set calculations. This makes mean calculation significantly faster than
using pyBigWig with more control over the binning algorithm.

Hopefully this machinery can also be used to replace binning and mean calculations in
calculating task covariates, which would provide significant speedup and simplify the
code quite a bit.

**Note,** however, that this breaks "backwards compatibility" with versions prior to this one (0.23). This means the same data input will result in a slightly different output.

Additionally, I	made writes to the training set file (in "fillTrainingSetMeta") buffered. Instead of writing every line directly to the file it writes them to a string buffer (which is much faster) and only writes the buffer to the file once.