### PR TITLE
[BUGFIX] Creating multiple lists like [[]] * n is incorrect

### DIFF
--- a/CRADLE/CorrectBiasStored/calculateOneBP.pyx
+++ b/CRADLE/CorrectBiasStored/calculateOneBP.pyx
@@ -103,8 +103,8 @@ cpdef getCoefs(model, covariates):
 	return coef
 
 cpdef correctReadCount(tasks, covariates, faFileName, ctrlBWNames, ctrlScaler, COEFCTRL, COEFCTRL_HIGHRC, experiBWNames, experiScaler, COEFEXP, COEFEXP_HIGHRC, highRC, minFragFilterValue, binsize, outputDir):
-	correctedCtrlReadCounts = [[]] * len(ctrlBWNames)
-	correctedExprReadCounts = [[]] * len(experiBWNames)
+	correctedCtrlReadCounts = [[] for _ in range(len(ctrlBWNames))]
+	correctedExprReadCounts = [[] for _ in range(len(experiBWNames))]
 
 	for taskArgs in tasks:
 		chromo = taskArgs[0]

--- a/tests/test_correctbiasutils.py
+++ b/tests/test_correctbiasutils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from CRADLE.correctbiasutils import divideGenome
+from CRADLE.correctbiasutils import divideGenome, rotateBWFileArrays
 
 # Semi-random regions
 rand_regions = [('chr1', 100, 30789), ('chr1', 100, 123123), ('chr1', 124434, 473629), ('chr1', 1234756, 1657483)]
@@ -60,3 +60,26 @@ gbs_regions = [('chr2', 100, 200100), ('chr2', 124434, 524435), ('chr2', 624434,
 ])
 def testDivideGenomeRand(regions, baseBinSize, genomeBinSize, result):
 	assert divideGenome(regions, baseBinSize, genomeBinSize) == result
+
+def testRotateBWFileArrays():
+	inputArray = [
+	  # Results of Job 0
+		[['ctrlFile0Temp0.msl', 'ctrlFile1Temp0.msl'], ['experiFile0Temp0.msl', 'experiFile1Temp0.msl'], ],
+	  # Results of Job 1
+		[['ctrlFile0Temp1.msl', 'ctrlFile1Temp1.msl'], ['experiFile0Temp1.msl', 'experiFile1Temp1.msl'], ],
+	  # Results of Job 2
+		[['ctrlFile0Temp2.msl', 'ctrlFile1Temp2.msl'], ['experiFile0Temp2.msl', 'experiFile1Temp2.msl'], ],
+	]
+
+	output = (
+		[
+			['ctrlFile0Temp0.msl', 'ctrlFile0Temp1.msl', 'ctrlFile0Temp2.msl'],
+			['ctrlFile1Temp0.msl', 'ctrlFile1Temp1.msl', 'ctrlFile1Temp2.msl']
+		],
+		[
+			['experiFile0Temp0.msl', 'experiFile0Temp1.msl', 'experiFile0Temp2.msl'],
+			['experiFile1Temp0.msl', 'experiFile1Temp1.msl', 'experiFile1Temp2.msl']
+		],
+	)
+
+	assert rotateBWFileArrays(inputArray, ['ctrlFile0', 'ctrlFile1'], ['experiFile0', 'experiFile1']) == output


### PR DESCRIPTION
This creates n copies of one list, not n lists. This means that
In [1]: a = [[]] * 5
In [2]: a[0].append(1)
In [3]: a
Out[3]: [[1], [1], [1], [1], [1]]

Which is not what we want.
In [1]: a = [[] for _ in range(5)]
In [2]: a[0].append(1)
In [3]: a
Out[3]: [[1], [], [], [], []]

is the desired behavior.

Pulls out the "rotate matrix of strings" code so it can be tested.
