### PR TITLE
Combines read count plots

### DIFF
--- a/CRADLE/CorrectBias/correctBias.py
+++ b/CRADLE/CorrectBias/correctBias.py
@@ -545,6 +545,27 @@ def run(args):
 	).get()
 	pool.close()
 	pool.join()
+
+	for name in vari.CTRLBW_NAMES:
+		fileName = utils.figureFileName(vari.OUTPUT_DIR, name)
+		regRCReadCounts, regRCFittedValues = coefResult[0][2][name]
+		highRCReadCounts, highRCFittedValues = coefResult[1][2][name]
+		utils.plot(
+			regRCReadCounts, regRCFittedValues,
+			highRCReadCounts, highRCFittedValues,
+			fileName
+		)
+
+	for name in vari.EXPBW_NAMES:
+		fileName = utils.figureFileName(vari.OUTPUT_DIR, name)
+		regRCReadCounts, regRCFittedValues = coefResult[0][3][name]
+		highRCReadCounts, highRCFittedValues = coefResult[1][3][name]
+		utils.plot(
+			regRCReadCounts, regRCFittedValues,
+			highRCReadCounts, highRCFittedValues,
+			fileName
+		)
+
 	del trainSetResult1, trainSetResult2
 	gc.collect()
 

--- a/CRADLE/CorrectBiasStored/correctBias.py
+++ b/CRADLE/CorrectBiasStored/correctBias.py
@@ -1,5 +1,6 @@
 import gc
 import multiprocessing
+import os
 import time
 
 import numpy as np
@@ -88,17 +89,37 @@ def run(args):
 		calculateOneBP.performRegression,
 		[
 			[
-				trainSet90Percentile, scatterplotSamples90Percentile, covariates, vari.CTRLBW_NAMES, vari.CTRLSCALER,
-				vari.EXPBW_NAMES, vari.EXPSCALER, vari.OUTPUT_DIR, "90_precentile"
+				trainSet90Percentile, covariates, vari.CTRLBW_NAMES, vari.CTRLSCALER, vari.EXPBW_NAMES, vari.EXPSCALER, scatterplotSamples90Percentile
 			],
 			[
-				trainSet90To99Percentile, scatterplotSamples90to99Percentile, covariates, vari.CTRLBW_NAMES, vari.CTRLSCALER,
-				vari.EXPBW_NAMES, vari.EXPSCALER, vari.OUTPUT_DIR, "90_to_99_percentile"
+				trainSet90To99Percentile, covariates, vari.CTRLBW_NAMES, vari.CTRLSCALER, vari.EXPBW_NAMES, vari.EXPSCALER, scatterplotSamples90to99Percentile
 			]
 		]
 	).get()
 	pool.close()
 	pool.join()
+
+
+
+	for name in vari.CTRLBW_NAMES:
+		fileName = utils.figureFileName(vari.OUTPUT_DIR, name)
+		regRCReadCounts, regRCFittedValues = coefResult[0][2][name]
+		highRCReadCounts, highRCFittedValues = coefResult[1][2][name]
+		utils.plot(
+			regRCReadCounts, regRCFittedValues,
+			highRCReadCounts, highRCFittedValues,
+			fileName
+		)
+
+	for name in vari.EXPBW_NAMES:
+		fileName = utils.figureFileName(vari.OUTPUT_DIR, name)
+		regRCReadCounts, regRCFittedValues = coefResult[0][3][name]
+		highRCReadCounts, highRCFittedValues = coefResult[1][3][name]
+		utils.plot(
+			regRCReadCounts, regRCFittedValues,
+			highRCReadCounts, highRCFittedValues,
+			fileName
+		)
 
 	del trainSet90Percentile, trainSet90To99Percentile
 	gc.collect()

--- a/CRADLE/correctbiasutils/__init__.py
+++ b/CRADLE/correctbiasutils/__init__.py
@@ -5,6 +5,8 @@ import math
 import multiprocessing
 import os
 import tempfile
+import matplotlib
+import matplotlib.pyplot as plt
 import numpy as np
 import pyBigWig
 import statsmodels.api as sm
@@ -12,6 +14,8 @@ import statsmodels.api as sm
 from shutil import copyfile
 
 from CRADLE.correctbiasutils.cython import array_split, generateNormalizedObBWs
+
+matplotlib.use('Agg')
 
 TRAINING_BIN_SIZE = 1000
 
@@ -460,12 +464,6 @@ def fillTrainingSetMeta(downLimit, upLimit, trainingRegionNum, regions, ctrlBWNa
 	os.remove(resultFile.name)
 	return None
 
-def getScatterplotSamples(trainingSet):
-	if trainingSet.xRowCount <= 50000:
-		return np.array(range(trainingSet.xRowCount))
-	else:
-		return np.random.choice(np.array(range(trainingSet.xRowCount)), 50000, replace=False)
-
 def alignCoordinatesToHDF(faFile, oldTrainingSet, fragLen):
 	trainingSet = []
 	xRowCount = 0
@@ -495,3 +493,41 @@ def alignCoordinatesToHDF(faFile, oldTrainingSet, fragLen):
 		trainingSet.append(TrainingRegion(chromo, analysisStart, analysisEnd))
 
 	return TrainingSet(trainingRegions=trainingSet, xRowCount=xRowCount)
+
+def getScatterplotSamples(trainingSet):
+	if trainingSet.xRowCount <= 10_000:
+		return np.arange(0, trainingSet.xRowCount)
+	else:
+		return np.random.choice(np.arange(0, trainingSet.xRowCount), 10_000, replace=False)
+
+def figureFileName(outputDir, bwFileName):
+	bwName = '.'.join(bwFileName.rsplit('/', 1)[-1].split(".")[:-1])
+	return os.path.join(outputDir, f"fit_{bwName}.png")
+
+def plot(regRCs, regRCFittedValues, highRCs, highRCFittedValues, figName):
+	fig, ax = plt.subplots()
+
+	corr = np.corrcoef(regRCFittedValues, regRCs)[0, 1]
+	corr = np.round(corr, 2)
+	maxi1 = np.nanmax(regRCFittedValues)
+	maxi2 = np.nanmax(regRCs)
+	maxiRegRC = max(maxi1, maxi2)
+	ax.plot(regRCs, regRCFittedValues, color='g', marker='s', alpha=0.01)
+
+	corr = np.corrcoef(highRCFittedValues, highRCs)[0, 1]
+	corr = np.round(corr, 2)
+	maxi1 = np.nanmax(highRCFittedValues)
+	maxi2 = np.nanmax(highRCs)
+	maxiHighRC = max(maxi1, maxi2)
+	ax.plot(highRCs, highRCFittedValues, color='g', marker='s', alpha=0.01)
+
+	maxi = max(maxiRegRC, maxiHighRC)
+
+	ax.text((maxi-25), 10, corr, ha='center', va='center')
+	ax.set_xlabel("observed")
+	ax.set_ylabel("predicted")
+	ax.set_xlim(0, maxi)
+	ax.set_ylim(0, maxi)
+	ax.plot([0, maxi], [0, maxi], 'k-', color='r')
+	ax.set_aspect('equal', adjustable='box')
+	fig.savefig(figName)

--- a/CRADLE/correctbiasutils/cython.pyx
+++ b/CRADLE/correctbiasutils/cython.pyx
@@ -1,11 +1,7 @@
 # cython: language_level=3
 
-import matplotlib
-import matplotlib.pyplot as plt
 import numpy as np
 import pyBigWig
-
-matplotlib.use('Agg')
 
 cpdef arraySplit(values, numBins, fillValue=np.nan):
 	"""Splits a numpy array of values into numBins "bins". If len(values) is not evenly

--- a/CRADLE/correctbiasutils/cython.pyx
+++ b/CRADLE/correctbiasutils/cython.pyx
@@ -1,9 +1,5 @@
-import matplotlib
-import matplotlib.pyplot as plt
 import numpy as np
 import pyBigWig
-
-matplotlib.use('Agg')
 
 cpdef array_split(values, numBins, fillValue=np.nan):
 	"""Splits a numpy array of values into numBins "bins". If len(values) is not evenly
@@ -127,25 +123,6 @@ cpdef generateNormalizedObBWs(bwHeader, scaler, regions, observedBWName, normObB
 	obBW.close()
 
 	return normObBWName
-
-cpdef plot(yView, fittedvalues, figName, scatterplotSamples):
-	corr = np.corrcoef(fittedvalues, np.array(yView))[0, 1]
-	corr = np.round(corr, 2)
-	maxi1 = np.nanmax(fittedvalues[scatterplotSamples])
-	maxi2 = np.nanmax(np.array(yView)[scatterplotSamples])
-	maxi = max(maxi1, maxi2)
-
-	plt.plot(np.array(yView)[scatterplotSamples], fittedvalues[scatterplotSamples], color='g', marker='s', alpha=0.01)
-	plt.text((maxi-25), 10, corr, ha='center', va='center')
-	plt.xlabel("observed")
-	plt.ylabel("predicted")
-	plt.xlim(0, maxi)
-	plt.ylim(0, maxi)
-	plt.plot([0, maxi], [0, maxi], 'k-', color='r')
-	plt.gca().set_aspect('equal', adjustable='box')
-	plt.savefig(figName)
-	plt.close()
-	plt.clf()
 
 cpdef writeBedFile(subfile, tempStarts, tempSignalvals, analysisEnd, binsize):
 	tempSignalvals = tempSignalvals.astype(int)


### PR DESCRIPTION
Previously the the high percentile read counts for a bw file were plotted
separately from the rest of the read counts. This combines the two into a
single plot.

To avoid using too much memory the read counts are returned from performRegression
pre-sampled.