### PR TITLE
Renames FA/faFile/fa to genome

### DIFF
--- a/CRADLE/CorrectBias/calculateOnebp.pyx
+++ b/CRADLE/CorrectBias/calculateOnebp.pyx
@@ -28,8 +28,8 @@ cpdef calculateContinuousFrag(chromo, analysisStart, analysisEnd, binStart, binE
 	shearStart = fragStart - 2
 	shearEnd = fragEnd + 2 # not included
 
-	faFile = py2bit.open(vari.FA)
-	chromoEnd = int(faFile.chroms(chromo))
+	genome = py2bit.open(vari.GENOME)
+	chromoEnd = int(genome.chroms(chromo))
 
 	if shearStart < 1:
 		shearStart = 1
@@ -82,8 +82,8 @@ cpdef calculateContinuousFrag(chromo, analysisStart, analysisEnd, binStart, binE
 	result = makeMatrixContinuousFrag(binStart, binEnd, nBins)
 
 	###### GET SEQUENCE
-	fa = faFile.sequence(chromo, (shearStart-1), (shearEnd-1))
-	faFile.close()
+	sequence = genome.sequence(chromo, (shearStart-1), (shearEnd-1))
+	genome.close()
 
 	##### OPEN BIAS FILES
 	if vari.MAP == 1:
@@ -118,9 +118,9 @@ cpdef calculateContinuousFrag(chromo, analysisStart, analysisEnd, binStart, binE
 		del gquadFile, gquadValue
 
 
-	##### INDEX IN 'fa'
-	startIdx = 2  # index in the fasta file (Included in the range)
-	endIdx = (fragEnd - vari.FRAGLEN) - shearStart + 1   # index in the fasta file (Not included in the range)
+	##### INDEX IN 'sequence'
+	startIdx = 2  # index in the genome sequence file (Included in the range)
+	endIdx = (fragEnd - vari.FRAGLEN) - shearStart + 1   # index in the genome sequence file (Not included in the range)
 
 	##### INITIALIZE VARIABLES
 	if vari.SHEAR == 1:
@@ -146,7 +146,7 @@ cpdef calculateContinuousFrag(chromo, analysisStart, analysisEnd, binStart, binE
 
 		if vari.SHEAR == 1:
 			###  mer1
-			mer1 = fa[(idx-2):(idx+3)]
+			mer1 = sequence[(idx-2):(idx+3)]
 			if 'N' in mer1:
 				pastMer1 = -1
 				mgwIdx = vari.N_MGW
@@ -159,7 +159,7 @@ cpdef calculateContinuousFrag(chromo, analysisStart, analysisEnd, binStart, binE
 
 			###  mer2
 			fragEndIdx = idx + vari.FRAGLEN
-			mer2 = fa[(fragEndIdx-3):(fragEndIdx+2)]
+			mer2 = sequence[(fragEndIdx-3):(fragEndIdx+2)]
 			if 'N' in mer2:
 				pastMer2 = -1
 				mgwIdx = mgwIdx + vari.N_MGW
@@ -178,12 +178,12 @@ cpdef calculateContinuousFrag(chromo, analysisStart, analysisEnd, binStart, binE
 
 
 		if vari.PCR == 1:
-			faIdx = fa[idx:(idx+vari.FRAGLEN)]
+			sequenceIdx = sequence[idx:(idx+vari.FRAGLEN)]
 			if pastStartGibbs == -1:
-				startGibbs, gibbs = findStartGibbs(faIdx, vari.FRAGLEN)
+				startGibbs, gibbs = findStartGibbs(sequenceIdx, vari.FRAGLEN)
 			else:
-				oldDimer = faIdx[0:2].upper()
-				newDimer = faIdx[(vari.FRAGLEN-2):vari.FRAGLEN].upper()
+				oldDimer = sequenceIdx[0:2].upper()
+				newDimer = sequenceIdx[(vari.FRAGLEN-2):vari.FRAGLEN].upper()
 				startGibbs, gibbs = editStartGibbs(oldDimer, newDimer, pastStartGibbs)
 
 			annealIdx, denatureIdx = convertGibbs(gibbs)
@@ -308,8 +308,8 @@ cpdef calculateDiscreteFrag(chromo, analysisStart, analysisEnd, binStart, binEnd
 	shearStart = fragStart - 2
 	shearEnd = fragEnd + 2 # not included
 
-	faFile = py2bit.open(vari.FA)
-	chromoEnd = int(faFile.chroms(chromo))
+	genome = py2bit.open(vari.GENOME)
+	chromoEnd = int(genome.chroms(chromo))
 
 	if shearStart < 1:
 		shearStart = 1
@@ -363,8 +363,8 @@ cpdef calculateDiscreteFrag(chromo, analysisStart, analysisEnd, binStart, binEnd
 	result = makeMatrixDiscreteFrag(binStart, binEnd, nBins)
 
 	###### GET SEQUENCE
-	fa = faFile.sequence(chromo, (shearStart-1), (shearEnd-1))
-	faFile.close()
+	sequence = genome.sequence(chromo, (shearStart-1), (shearEnd-1))
+	genome.close()
 
 	##### OPEN BIAS FILES
 	if vari.MAP == 1:
@@ -442,7 +442,7 @@ cpdef calculateDiscreteFrag(chromo, analysisStart, analysisEnd, binStart, binEnd
 
 			if vari.SHEAR == 1:
 				###  mer1
-				mer1 = fa[(idx-2):(idx+3)]
+				mer1 = sequence[(idx-2):(idx+3)]
 				if 'N' in mer1:
 					pastMer1 = -1
 					mgwIdx = vari.N_MGW
@@ -455,7 +455,7 @@ cpdef calculateDiscreteFrag(chromo, analysisStart, analysisEnd, binStart, binEnd
 
 				###  mer2
 				fragEndIdx = idx + vari.FRAGLEN
-				mer2 = fa[(fragEndIdx-3):(fragEndIdx+2)]
+				mer2 = sequence[(fragEndIdx-3):(fragEndIdx+2)]
 				if 'N' in mer2:
 					pastMer2 = -1
 					mgwIdx = mgwIdx + vari.N_MGW
@@ -473,12 +473,12 @@ cpdef calculateDiscreteFrag(chromo, analysisStart, analysisEnd, binStart, binEnd
 				covariIdxPtr = covariIdxPtr + 2
 
 			if vari.PCR == 1:
-				faIdx = fa[idx:(idx+vari.FRAGLEN)]
+				sequenceIdx = sequence[idx:(idx+vari.FRAGLEN)]
 				if pastStartGibbs == -1:
-					startGibbs, gibbs = findStartGibbs(faIdx, vari.FRAGLEN)
+					startGibbs, gibbs = findStartGibbs(sequenceIdx, vari.FRAGLEN)
 				else:
-					oldDimer = faIdx[0:2].upper()
-					newDimer = faIdx[(vari.FRAGLEN-2):vari.FRAGLEN].upper()
+					oldDimer = sequenceIdx[0:2].upper()
+					newDimer = sequenceIdx[(vari.FRAGLEN-2):vari.FRAGLEN].upper()
 					startGibbs, gibbs = editStartGibbs(oldDimer, newDimer, pastStartGibbs)
 
 				annealIdx, denatureIdx = convertGibbs(gibbs)
@@ -535,8 +535,8 @@ cpdef calculateTrainCovariates(args):
 	shearStart = fragStart - 2
 	shearEnd = fragEnd + 2 # not included
 
-	faFile = py2bit.open(vari.FA)
-	chromoEnd = int(faFile.chroms(chromo))
+	genome = py2bit.open(vari.GENOME)
+	chromoEnd = int(genome.chroms(chromo))
 
 	if shearStart < 1:
 		shearStart = 1
@@ -555,8 +555,8 @@ cpdef calculateTrainCovariates(args):
 	result = makeMatrixContinuousFragTrain(binStart, binEnd, nBins)
 
 	###### GET SEQUENCE
-	fa = faFile.sequence(chromo, (shearStart-1), (shearEnd-1))
-	faFile.close()
+	sequence = genome.sequence(chromo, (shearStart-1), (shearEnd-1))
+	genome.close()
 
 	##### OPEN BIAS FILES
 	if vari.MAP == 1:
@@ -591,9 +591,9 @@ cpdef calculateTrainCovariates(args):
 		del gquadFile, gquadValue
 
 
-	##### INDEX IN 'fa'
-	startIdx = 2  # index in the fasta file (Included in the range)
-	endIdx = (fragEnd - vari.FRAGLEN) - shearStart + 1   # index in the fasta file (Not included in the range)
+	##### INDEX IN 'sequence'
+	startIdx = 2  # index in the genome sequence file (Included in the range)
+	endIdx = (fragEnd - vari.FRAGLEN) - shearStart + 1   # index in the genome sequence file (Not included in the range)
 
 	##### INITIALIZE VARIABLES
 	if vari.SHEAR == 1:
@@ -619,7 +619,7 @@ cpdef calculateTrainCovariates(args):
 
 		if vari.SHEAR == 1:
 			###  mer1
-			mer1 = fa[(idx-2):(idx+3)]
+			mer1 = sequence[(idx-2):(idx+3)]
 			if 'N' in mer1:
 				pastMer1 = -1
 				mgwIdx = vari.N_MGW
@@ -632,7 +632,7 @@ cpdef calculateTrainCovariates(args):
 
 			##  mer2
 			fragEndIdx = idx + vari.FRAGLEN
-			mer2 = fa[(fragEndIdx-3):(fragEndIdx+2)]
+			mer2 = sequence[(fragEndIdx-3):(fragEndIdx+2)]
 			if 'N' in mer2:
 				pastMer2 = -1
 				mgwIdx = mgwIdx + vari.N_MGW
@@ -651,12 +651,12 @@ cpdef calculateTrainCovariates(args):
 
 
 		if vari.PCR == 1:
-			faIdx = fa[idx:(idx+vari.FRAGLEN)]
+			sequenceIdx = sequence[idx:(idx+vari.FRAGLEN)]
 			if pastStartGibbs == -1:
-				startGibbs, gibbs = findStartGibbs(faIdx, vari.FRAGLEN)
+				startGibbs, gibbs = findStartGibbs(sequenceIdx, vari.FRAGLEN)
 			else:
-				oldDimer = faIdx[0:2].upper()
-				newDimer = faIdx[(vari.FRAGLEN-2):vari.FRAGLEN].upper()
+				oldDimer = sequenceIdx[0:2].upper()
+				newDimer = sequenceIdx[(vari.FRAGLEN-2):vari.FRAGLEN].upper()
 				startGibbs, gibbs = editStartGibbs(oldDimer, newDimer, pastStartGibbs)
 
 			annealIdx, denatureIdx = convertGibbs(gibbs)

--- a/CRADLE/CorrectBias/vari.py
+++ b/CRADLE/CorrectBias/vari.py
@@ -70,7 +70,7 @@ def setBiasFiles(args):
 	global MAP
 	global GQUAD
 	global COVARI_NUM
-	global FA
+	global GENOME
 	global COVARI_ORDER
 
 	SHEAR = 0
@@ -78,7 +78,7 @@ def setBiasFiles(args):
 	MAP = 0
 	GQUAD = 0
 
-	FA = args.faFile
+	GENOME = args.genome
 
 	COVARI_NUM = 0
 

--- a/CRADLE/CorrectBiasStored/calculateOneBP.pyx
+++ b/CRADLE/CorrectBiasStored/calculateOneBP.pyx
@@ -116,7 +116,7 @@ cpdef getCoefs(modelParams, selectedCovariates):
 
 	return coef
 
-cpdef correctReadCount(tasks, covariates, faFileName, ctrlBWNames, ctrlScaler, COEFCTRL, COEFCTRL_HIGHRC, experiBWNames, experiScaler, COEFEXP, COEFEXP_HIGHRC, highRC, minFragFilterValue, binsize, outputDir):
+cpdef correctReadCount(tasks, covariates, genome, ctrlBWNames, ctrlScaler, COEFCTRL, COEFCTRL_HIGHRC, experiBWNames, experiScaler, COEFEXP, COEFEXP_HIGHRC, highRC, minFragFilterValue, binsize, outputDir):
 	correctedCtrlReadCounts = [[] for _ in range(len(ctrlBWNames))]
 	correctedExprReadCounts = [[] for _ in range(len(experiBWNames))]
 
@@ -125,8 +125,8 @@ cpdef correctReadCount(tasks, covariates, faFileName, ctrlBWNames, ctrlScaler, C
 		analysisStart = int(taskArgs[1])  # Genomic coordinates(starts from 1)
 		analysisEnd = int(taskArgs[2])
 
-		with py2bit.open(faFileName) as faFile:
-			chromoEnd = int(faFile.chroms(chromo))
+		with py2bit.open(genome) as genomeFile:
+			chromoEnd = int(genomeFile.chroms(chromo))
 
 		###### GENERATE A RESULT MATRIX
 		fragStart = analysisStart - covariates.fragLen + 1

--- a/CRADLE/CorrectBiasStored/correctBias.py
+++ b/CRADLE/CorrectBiasStored/correctBias.py
@@ -82,9 +82,9 @@ def run(args):
 	if len(trainSet90To99Percentile) == 0:
 		trainSet90To99Percentile = vari.REGION
 
-	with py2bit.open(vari.FA) as faFile:
-		trainSet90Percentile = utils.alignCoordinatesToHDF(faFile, trainSet90Percentile, covariates.fragLen)
-		trainSet90To99Percentile = utils.alignCoordinatesToHDF(faFile, trainSet90To99Percentile, covariates.fragLen)
+	with py2bit.open(vari.GENOME) as genome:
+		trainSet90Percentile = utils.alignCoordinatesToHDF(genome, trainSet90Percentile, covariates.fragLen)
+		trainSet90To99Percentile = utils.alignCoordinatesToHDF(genome, trainSet90To99Percentile, covariates.fragLen)
 
 	scatterplotSamples90Percentile = utils.getScatterplotSampleIndices(trainSet90Percentile.xRowCount)
 	scatterplotSamples90to99Percentile = utils.getScatterplotSampleIndices(trainSet90To99Percentile.xRowCount)
@@ -167,7 +167,7 @@ def run(args):
 	crcArgs = zip(
 		taskGroups,
 		[covariates] * jobCount,
-		[vari.FA] * jobCount,
+		[vari.GENOME] * jobCount,
 		[vari.CTRLBW_NAMES] * jobCount,
 		[vari.CTRLSCALER] * jobCount,
 		[vari.COEFCTRL] * jobCount,

--- a/CRADLE/CorrectBiasStored/vari.py
+++ b/CRADLE/CorrectBiasStored/vari.py
@@ -8,7 +8,7 @@ def setGlobalVariables(args):
 	### input bigwig files
 	setInputFiles(args.ctrlbw, args.expbw)
 	setOutputDirectory(args.o)
-	setCovariDir(args.biasType, args.covariDir, args.faFile)
+	setCovariDir(args.biasType, args.covariDir, args.genome)
 	setAnlaysisRegion(args.r, args.bl)
 	setFilterCriteria(args.mi)
 	setNumProcess(args.p)
@@ -97,12 +97,12 @@ def setOutputDirectory(outputDir):
 def getStoredCovariates(biasTypes, covariDir):
 	return StoredCovariates(biasTypes, covariDir)
 
-def setCovariDir(biasType, covariDir, faFile):
+def setCovariDir(biasType, covariDir, genome):
 	global COVARI_DIR
 	global COVARI_NAME
 	global SELECT_COVARI
 	global FRAGLEN
-	global FA
+	global GENOME
 	global COVARI_NUM
 	global BINSIZE
 	global COVARI_ORDER
@@ -121,7 +121,7 @@ def setCovariDir(biasType, covariDir, faFile):
 	tempStr = COVARI_NAME.split("_")[1]
 	FRAGLEN = int(tempStr.split("fragLen")[1])
 
-	FA = faFile
+	GENOME = genome
 	BINSIZE = 1
 
 	SELECT_COVARI = np.array([np.nan] * 6)

--- a/CRADLE/correctbiasutils/__init__.py
+++ b/CRADLE/correctbiasutils/__init__.py
@@ -493,7 +493,7 @@ def fillTrainingSetMeta(downLimit, upLimit, trainingRegionNum, regions, ctrlBWNa
 	os.remove(resultFile.name)
 	return None
 
-def alignCoordinatesToHDF(faFile, oldTrainingSet, fragLen):
+def alignCoordinatesToHDF(genome, oldTrainingSet, fragLen):
 	trainingSet = []
 	xRowCount = 0
 
@@ -501,7 +501,7 @@ def alignCoordinatesToHDF(faFile, oldTrainingSet, fragLen):
 		chromo = trainingRegion[0]
 		analysisStart = int(trainingRegion[1])
 		analysisEnd = int(trainingRegion[2])
-		chromoEnd = faFile.chroms(chromo)
+		chromoEnd = genome.chroms(chromo)
 
 		fragStart = analysisStart - fragLen + 1
 		fragEnd = analysisEnd + fragLen - 1

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cradle correctBias -ctrlbw ctrl1.bw ctrl2.bw ctrl3.bw
                    -l 500
                    -r /data/YoungSook/target_region.bed
                    -biasType shear pcr map gquad
-                   -faFile /data/YoungSook/hg38.2bit
+                   -genome /data/YoungSook/hg38.2bit
                    -kmer 50
                    -o /data/YoungSook/CRADLE_result
                    -bl /data/YoungSook/blacklist_regions.bed
@@ -76,8 +76,8 @@ cradle correctBias -ctrlbw ctrl1.bw ctrl2.bw ctrl3.bw
       Text file that shows regions of analysis. Each line in the text file should have chromosome, start site, and end site that are tab-spaced. ex) chr1\t100\t3000
   -  -biasType <br />
       Type of biases you want to correct among 'shear', 'pcr', 'map', 'gquad'. If you want to correct 'shear' and 'pcr' bias, you should type -biasType shear pcr. If you type map, -mapFile and -kmer are required. If you type gquad, -gquadFile is required
-  -  -faFile <br />
-       .2bit files. You can download .2bit files in UCSC genome browser. <br/> <br/>
+  -  -genome <br />
+       The human genome sequence, in .2bit format. For information on downloading the genome, see [https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/](https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/) §§ "Files" and "How to Download"<br/> <br/>
 * Optional Arguments <br />
    !! Warning !! Some optional arguments are required depending on what you put in required arguments. <br />
   -  -binSize <br />
@@ -117,7 +117,7 @@ cradle correctBias_stored -ctrlbw ctrl1.bw ctrl2.bw ctrl3.bw
                           -r /data/YoungSook/target_region.bed
                           -biasType shear pcr map gquad
                           -covariDir /data/YoungSook/hg39_fragLen500_kmer50
-                          -faFile /data/YoungSook/hg38.2bit
+                          -genome /data/YoungSook/hg38.2bit
                           -kmer 50
                           -o /data/YoungSook/CRADLE_result
                           -bl /data/YoungSook/blacklist_regions.bed
@@ -134,8 +134,8 @@ cradle correctBias_stored -ctrlbw ctrl1.bw ctrl2.bw ctrl3.bw
       Type of biases you want to correct among 'shear', 'pcr', 'map', 'gquad'. If you want to correct 'shear' and 'pcr' bias, you should type -biasType shear pcr.
   -  -covariDir <br />
       The directory of hdf files that have covariate values. The directory name of covariate files should be 'refGenome_fragLen(fragment length)_kmer(the length of sequenced reads)' ex) hg38_fragLen300_kmer36
-  -  -faFile <br/>
-      .2bit files. You can download .2bit files in UCSC genome browser. <br/> <br/>
+  -  -genome <br/>
+      The human genome sequence, in .2bit format. For information on downloading the genome, see [https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/](https://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/) §§ "Files" and "How to Download"<br/> <br/>
 
 * Optional Arguments
   -  -mi <br />
@@ -278,7 +278,7 @@ singularity run --bind /data cradle.sif correctBias_stored \
     -expbw /data/unnormalized/exp_unnormalized.bw \
     -r /data/ref_genome/regionfile_correctionModel \
     -biasType shear pcr map gquad \
-    -faFile /data/ref_genome/hg38/hg38.2bit \
+    -genome /data/ref_genome/hg38/hg38.2bit \
     -covariDir /data/covariateFiles/hg38_fragLen1000_kmer50 \
     -mi 125 \
     -p 10 \
@@ -294,7 +294,7 @@ However, if all your data is in a directory singularity mounts by default you ca
     -expbw unnormalized/exp_unnormalized.bw \
     -r ref_genome/regionfile_correctionModel \
     -biasType shear pcr map gquad \
-    -faFile ref_genome/hg38/hg38.2bit \
+    -genome ref_genome/hg38/hg38.2bit \
     -covariDir covariateFiles/hg38_fragLen1000_kmer50 \
     -mi 125 \
     -p 10 \
@@ -309,7 +309,7 @@ However, if all your data is in a directory singularity mounts by default you ca
    Derrien T, Estellé J, Marco Sola S, Knowles DG, Raineri E, Guigó R, Ribeca P. Fast computation and applications of genome mappability. PLoS One. 2012;7(1):e30377. <br />
 3) G-quadruplex sturcture <br/>
    Chambers VS, Marsico G, Boutell JM, Di Antonio M, Smith GP, Balasubramanian S. High-throughput sequencing of DNA G-quadruplex structures in the human genome.Nat Biotechnol. 2015 Aug;33(8):877-81.<br />
-   
+
  ## Cite CRADLE
 Kim YS, Johnson GD, Seo J, Barrera A, Cowart TN, Majoros WH, Ochoa A, Allen AS, Reddy TE. Correcting signal biases and detecting regulatory elements in STARR-seq data. Genome Res. 2021 May;31(5):877-889. doi: 10.1101/gr.269209.120. Epub 2021 Mar 15. PMID: 33722938; PMCID: PMC8092017.
 

--- a/bin/cradle
+++ b/bin/cradle
@@ -10,134 +10,81 @@ def getArgs():
 
 	########### correctBias
 	correctBias_parser = subparsers.add_parser("correctBias", help="Correct shear, pcr, mappability, g-quadruplex sturcture bias from bigwig files")
-	## required
+
 	correctBias_required = correctBias_parser.add_argument_group("Required Args")
-
 	correctBias_required.add_argument('-ctrlbw', help="Ctrl bigwig files. Un-noramlized files are recommended. Each file name should be spaced. ex) -ctrlbw file1.bw file2.bw", nargs='+', required=True)
-
 	correctBias_required.add_argument('-expbw', help="Experimental bigwig files. Un-noramlized files are recommended. Each file name should be spaced. ex) -expbw file1.bw file2.bw", nargs='+', required=True)
-
 	correctBias_required.add_argument('-l', help="Fragment length.", required=True)
-
 	correctBias_required.add_argument('-r', help="Text file that shows regions of analysis. Each line in the text file should have chromosome, start site, and end site that are tab-spaced. ex) chr1\t100\t3000", required=True)
-
 	correctBias_required.add_argument('-biasType', help="Type of biases you want to correct among 'shear', 'pcr', 'map', 'gquad'. If you want to correct 'shear' and 'pcr' bias, you should type -biasType shear pcr. If you type map, -mapFile and -kmer are required. If you type gquad, -gquadFile is required", nargs='+', required=True)
+	correctBias_required.add_argument('-genome', '-faFile', help=".2bit file.", required=True) # faFile is deprecated
 
-	correctBias_required.add_argument('-faFile', help=".2bit file.", required=True)
-
-
-	## optional
 	correctBias_optional = correctBias_parser.add_argument_group("Optional Args")
-
 	correctBias_optional.add_argument('-binSize', help="The size of bin (bp) for correction. If you put '1', it means you want to correct read counts in single-bp resolution. (default=1)", default=1)
-
 	correctBias_optional.add_argument('-mi', help="The minimum number of fragments. Positions that have less fragments than this value are filtered out. default=the number of samples")
-
 	correctBias_optional.add_argument('-mapFile', help="Mappability file in bigwig format. Required when 'map' is in '-biasType'")
-
 	correctBias_optional.add_argument('-kmer', help="The length of sequencing reads. If you have paired-end sequencing with 50mer from each end, type '50'. Required when 'map' is in '-biasType'")
-
 	correctBias_optional.add_argument('-gquadFile', help="Gqaudruplex files in bigwig format. Multiple files are allowed. Required when 'gquad' is in '-biasType'", nargs="+")
-
 	correctBias_optional.add_argument('-gquadMax', help="The maximum gquad score. This is used to normalize Gquad score. default=78.6", default=78.6)
-
 	correctBias_optional.add_argument('-o', help="Output directory. All corrected bigwig files will be stored here. If the directory doesn't exist, cradle will make the directory. default=CRADLE_correctionResult")
-
 	correctBias_optional.add_argument('-p', help="The number of cpus. default=(available cpus)/2")
-
 	correctBias_optional.add_argument('-bl', help="Text file that shows regions you want to filter out. Each line in the text file should have chromosome, start site, and end site that are tab-spaced. ex) chr1\t1\t100")
-
 	correctBias_optional.add_argument('-norm', help="Whether normalization is needed for input bigwig files. Choose either 'True' or 'False'. default=True", default='True')
-
 	correctBias_optional.add_argument('-generateNormBW', help="If you want to generate normalized observed bigwig files, type 'True' (only works when '-norm True'). If you don't want, type 'False'. default=False", default='False')
-
 	correctBias_optional.add_argument('-rngSeed', type=int, help="Set seed value for the RNG. Enables repeatable runs.", default=None)
 
 
 	########### correctBias_stored
 	correctBiasStored_parser = subparsers.add_parser("correctBias_stored", help="Correct shear, pcr, mappability, g-quadruplex sturcture bias from bigwig files when there are stored covariate hdf5 files. This is much faster than correctBias.")
-	## required
+
 	correctBiasStored_required = correctBiasStored_parser.add_argument_group("Required Args")
-
 	correctBiasStored_required.add_argument('-ctrlbw', help="Ctrl bigwig files. Un-noramlized files are recommended. Each file name should be spaced. ex) -ctrlbw file1.bw file2.bw", nargs='+', required=True)
-
 	correctBiasStored_required.add_argument('-expbw', help="Experimental bigwig files. Un-noramlized files are recommended. Each file name should be spaced. ex) -expbw file1.bw file2.bw", nargs='+', required=True)
-
 	correctBiasStored_required.add_argument('-r', help="Text file that shows regions of analysis. Each line in the text file should have chromosome, start site, and end site that are tab-spaced. ex) chr1\t100\t3000", required=True)
-
 	correctBiasStored_required.add_argument('-biasType', help="Type of biases you want to correct among 'shear', 'pcr', 'map', 'gquad'. If you want to correct 'shear' and 'pcr' bias, you should type -biasType shear pcr.", nargs='+', required=True)
-
 	correctBiasStored_required.add_argument('-covariDir', help="The directory of hdf files that have covariate values. The directory name of covariate files should be 'refGenome_fragLen(fragment length)_kmer(the length of sequenced reads)' ex) hg38_fragLen300_kmer36", required=True)
+	correctBiasStored_required.add_argument('-genome', '-faFile', help=".2bit file.", required=True) # faFile is deprecated
 
-	correctBiasStored_required.add_argument('-faFile', help=".2bit file.", required=True)
-
-	## optional
 	correctBiasStored_optional = correctBiasStored_parser.add_argument_group("Optional Args")
-
 	correctBiasStored_optional.add_argument('-mi', help="The minimum number of fragments. Positions that have less fragments than this value are filtered out. default=the number of samples")
-
 	correctBiasStored_optional.add_argument('-o', help="Output directory. All corrected bigwig files will be stored here. If the directory doesn't exist, cradle will make the directory. default=CRADLE_correctionResult.")
-
 	correctBiasStored_optional.add_argument('-p', help="The number of cpus. default=(available cpus)/2")
-
 	correctBiasStored_optional.add_argument('-bl', help="Text file that shows regions you want to filter out. Each line in the text file should have chromosome, start site, and end site that are tab-spaced. ex) chr1\t1\t100")
-
 	correctBiasStored_optional.add_argument('-norm', help="Whether normalization is needed for input bigwig files. Choose either 'True' or 'False'. default=True", default='True')
-
 	correctBiasStored_optional.add_argument('-generateNormBW', help="If you want to generate normalized observed bigwig files, type 'True' (only works when '-norm True'). If you don't want, type 'False'. default=False", default='False')
-
 	correctBiasStored_optional.add_argument('-rngSeed', type=int, help="Set seed value for the RNG. Enables repeatable runs.", default=None)
 
 
 	########### callPeak
 	callPeak_parser = subparsers.add_parser("callPeak", help="Correct peaks with corrected bigwig files")
-	## required
+
 	callPeak_required = callPeak_parser.add_argument_group("Required Args")
-
 	callPeak_required.add_argument('-ctrlbw', help="Ctrl bigwig files. Corrected bigwig files are recommended. Each file name should be spaced. ex) -ctrlbw file1.bw file2.bw", nargs='+', required=True)
-
 	callPeak_required.add_argument('-expbw', help="Experimental bigwig files. Corrected bigwig files are recommended. Each file name should be spaced. ex) -expbw file1.bw file2.bw", nargs='+', required=True)
-
 	callPeak_required.add_argument('-r', help="Text file that shows regions of analysis. Each line in the text file should have chromosome, start site, and end site that are tab-spaced. ex) chr1\t100\t3000", required=True)
-
 	callPeak_required.add_argument('-fdr', help="FDR control", required=True)
 
-	## optional
 	callPeak_optional = callPeak_parser.add_argument_group("Optional Args")
-
 	callPeak_optional.add_argument('-o', help="Output directory. All corrected bigwig files will be stored here. If the directory doesn't exist, cradle will make the directory. default=CRADLE_peak_result.")
-
 	callPeak_optional.add_argument('-bl', help="Text file that shows regions you want to filter out. Each line in the text file should have chromosome, start site, and end site that are tab-spaced. ex) chr1\t1\t100")
-
 	callPeak_optional.add_argument('-rbin', help="The size of a bin used for defining regions. rbin cannot be smaller than wbin. default = 300")
-
 	callPeak_optional.add_argument('-wbin', help="The size of a bin used for testing differential activity. wbin cannot be larger than rbin. default = rbin/6")
-
 	callPeak_optional.add_argument('-p', help="The number of cpus. default=(available cpus)/2")
-
 	callPeak_optional.add_argument('-d', help="The minimum distance between peaks. Peaks distanced less than this value(bp) are merged. default=10")
-
 	callPeak_optional.add_argument('-pl', help="Minimum peak length. default=wbin")
+	callPeak_optional.add_argument('-stat', help="Choose a statistical testing: 't-test' for t-test and  'welch' for welch's t-test  default=t-test")
 
-	callPeak_optional.add_argument('-stat', help="Choose a statistical testing: 't-test' for t-test and  'welch' for welch's t-test  default=t-test")	
 
-
-	########### callPeak
+	########### normalize
 	normalize_parser = subparsers.add_parser("normalize", help="Normalize bigwgis across samples and across different regions of one sample. This is useful for BAC STARR-seq where you can even uneven coverage for each BAC regions or for each overlapping BAC regions")
-	## required
+
 	normalize_required = normalize_parser.add_argument_group("Required Args")
-
 	normalize_required.add_argument('-r', help="Text file that shows regions of analysis. Each line in the text file should have chromosome, start site, and end site that are tab-spaced. ex) chr1\t100\t3000", required=True)
-
 	normalize_required.add_argument('-ctrlbw', help="Unnormalized control bigwig files. Each file name should be spaced. ex) -ctrlbw file1.bw file2.bw", required=True, nargs="+")
-
 	normalize_required.add_argument('-expbw', help="Unnormalized experimental  bigwig files. Each file name should be spaced. ex) -ctrlbw file1.bw file2.bw", required=True, nargs="+")
 
-	## optional
 	normalize_optional = normalize_parser.add_argument_group("Optional Args")
-
 	normalize_optional.add_argument('-p', help="The number of cpus. default=(available cpus)/2", required=False)
-
 	normalize_optional.add_argument('-o', help="Output directory. All normalized bigwig files will be stored here. If the directory doesn't exist, cradle will make the directory. default=CRADLE_normalization.", required=False)
 
 	return parser


### PR DESCRIPTION
"fa" was short for "fasta", a file format. However, the data format CRADLE
expects is 2bit, so the name was misleading on that account.

Beyond the inaccuracy of the names, though, I don't think they described the
right thing. The file contains the sequences of the human genome and that's
what's important -- not the file format. So I've changed all the references
from fa/FA/etc. to genome/GENOME/etc.

The old "-faFile" command line argument still works, for backwards compatability,
but it's no longer documented and should be considered deprecated.
