### PR TITLE
More fully flesh out ChromoRegion* classes

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -7,9 +7,7 @@ on: [ push ]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.9

--- a/CRADLE/CorrectBias/vari.py
+++ b/CRADLE/CorrectBias/vari.py
@@ -5,15 +5,20 @@ import sys
 import numpy as np
 import pyBigWig
 
-from CRADLE.correctbiasutils import ChromoRegion, ChromoRegionSet
+from CRADLE.correctbiasutils import ChromoRegionSet
 
 def setGlobalVariables(args):
+	global REGIONS
+
 	### input bigwig files
 	setInputFiles(args.ctrlbw, args.expbw)
 	setOutputDirectory(args.o)
 	setBiasFiles(args)
 	setFragLen(args.l)
-	setAnlaysisRegion(args.r, args.bl)
+	with pyBigWig.open(CTRLBW_NAMES[0]) as ctrlBW:
+		regionSet = ChromoRegionSet.loadBed(args.r)
+		blacklistRegionSet = ChromoRegionSet.loadBed(args.bl) if args.bl else None
+		REGIONS = setAnlaysisRegion(regionSet, blacklistRegionSet, ctrlBW)
 	setFilterCriteria(args.mi)
 	setBinSize(args.binSize)
 	setNumProcess(args.p)
@@ -697,178 +702,27 @@ def setFragLen(fragLen):
 	global FRAGLEN
 	FRAGLEN = int(fragLen)
 
-def setAnlaysisRegion(regionsFilename, bl):
-	global REGIONS
+def setAnlaysisRegion(regionSet, blacklistRegionSet, ctrlBW):
+	regionSet.mergeRegions()
 
-	with open(regionsFilename) as regions:
-		regionLines = regions.readlines()
+	if blacklistRegionSet is not None:
+		blacklistRegionSet.mergeRegions()
+		regionSetWoBL = regionSet - blacklistRegionSet
+	else:
+		regionSetWoBL = regionSet
 
-	baseRegions = []
-	for line in regionLines:
-		chromo, start, end = line.split()
-		start = int(start)
-		end = int(end)
-		baseRegions.append((chromo, start, end))
+	finalRegionSet = ChromoRegionSet()
+	for region in regionSetWoBL:
+		chromoLen = ctrlBW.chroms(region.chromo)
+		if chromoLen is None or chromoLen <= region.start:
+			continue
 
-	mergedRegions = baseRegions
-	if len(baseRegions) > 1:
-		baseRegions = np.array(baseRegions)
-		sortedRegions = baseRegions[np.lexsort(( baseRegions[:,1].astype(int), baseRegions[:,0])  ) ]
-		sortedRegions = sortedRegions.tolist()
+		if region.end > chromoLen:
+			region.end = chromoLen
 
-		pos = 0
-		pastChromo, pastStart, pastEnd = sortedRegions[pos]
+		finalRegionSet.addRegion(region)
 
-		mergedRegions = [[pastChromo, pastStart, pastEnd]]
-		resultIdx = 0
-
-		pos = 1
-		while pos < len(sortedRegions):
-			currChromo, currStart, currEnd = sortedRegions[pos]
-
-			if (currChromo == pastChromo) and (currStart >= pastStart) and (currStart <= pastEnd):
-				maxEnd = max(currEnd, pastEnd)
-				mergedRegions[resultIdx][2] = maxEnd
-				pos = pos + 1
-				pastChromo = currChromo
-				pastStart = currStart
-				pastEnd = maxEnd
-			else:
-				mergedRegions.append([currChromo, currStart, currEnd])
-				resultIdx = resultIdx + 1
-				pos = pos + 1
-				pastChromo = currChromo
-				pastStart = currStart
-				pastEnd = currEnd
-
-	## BL
-	regionsWoBL = mergedRegions
-	if bl is not None:  ### REMOVE BLACKLIST REGIONS FROM 'REGIONS'
-		regionsWoBL = []
-		blRegionTemp = []
-		inputStream = open(bl)
-		inputFile = inputStream.readlines()
-		for i in range(len(inputFile)):
-			temp = inputFile[i].split()
-			temp[1] = int(temp[1])
-			temp[2] = int(temp[2])
-			blRegionTemp.append(temp)
-
-		## merge overlapping blacklist regions
-		if len(blRegionTemp) == 1:
-			blRegion = blRegionTemp
-			blRegion = np.array(blRegion)
-		else:
-			blRegionTemp = np.array(blRegionTemp)
-			blRegionTemp = blRegionTemp[np.lexsort( ( blRegionTemp[:,1].astype(int), blRegionTemp[:,0] ) )]
-			blRegionTemp = blRegionTemp.tolist()
-
-			blRegion = []
-			pos = 0
-			pastChromo = blRegionTemp[pos][0]
-			pastStart = int(blRegionTemp[pos][1])
-			pastEnd = int(blRegionTemp[pos][2])
-			blRegion.append([pastChromo, pastStart, pastEnd])
-			resultIdx = 0
-
-			pos = 1
-			while pos < len(blRegionTemp):
-				currChromo = blRegionTemp[pos][0]
-				currStart = int(blRegionTemp[pos][1])
-				currEnd = int(blRegionTemp[pos][2])
-
-				if (currChromo == pastChromo) and (currStart >= pastStart) and (currStart <= pastEnd):
-					blRegion[resultIdx][2] = currEnd
-					pos = pos + 1
-					pastChromo = currChromo
-					pastStart = currStart
-					pastEnd = currEnd
-				else:
-					blRegion.append([currChromo, currStart, currEnd])
-					resultIdx = resultIdx + 1
-					pos = pos + 1
-					pastChromo = currChromo
-					pastStart = currStart
-					pastEnd = currEnd
-			blRegion = np.array(blRegion)
-
-		for region in mergedRegions:
-			regionChromo, regionStart, regionEnd = region
-
-			overlappedBL = []
-			## overlap Case 1 : A blacklist region completely covers the region.
-			idx = np.where(
-				(blRegion[:,0] == regionChromo) &
-				(blRegion[:,1].astype(int) <= regionStart) &
-				(blRegion[:,2].astype(int) >= regionEnd)
-				)[0]
-			if len(idx) > 0:
-				continue
-
-			## overlap Case 2
-			idx = np.where(
-				(blRegion[:,0] == regionChromo) &
-				(blRegion[:,2].astype(int) > regionStart) &
-				(blRegion[:,2].astype(int) <= regionEnd)
-				)[0]
-			if len(idx) > 0:
-				overlappedBL.extend( blRegion[idx].tolist() )
-
-			## overlap Case 3
-			idx = np.where(
-				(blRegion[:,0] == regionChromo) &
-				(blRegion[:,1].astype(int) >= regionStart) &
-				(blRegion[:,1].astype(int) < regionEnd)
-				)[0]
-			if len(idx) > 0:
-				overlappedBL.extend( blRegion[idx].tolist() )
-
-			if len(overlappedBL) == 0:
-				regionsWoBL.append(region)
-				continue
-
-			overlappedBL = np.array(overlappedBL)
-			overlappedBL = overlappedBL[overlappedBL[:,1].astype(int).argsort()]
-			overlappedBL = np.unique(overlappedBL, axis=0)
-			overlappedBL = overlappedBL[overlappedBL[:,1].astype(int).argsort()]
-
-			currStart = regionStart
-			for pos in range(len(overlappedBL)):
-				blStart = int(overlappedBL[pos][1])
-				blEnd = int(overlappedBL[pos][2])
-
-				if blStart <= regionStart:
-					currStart = blEnd
-				else:
-					if currStart == blStart:
-						currStart = blEnd
-						continue
-
-					regionsWoBL.append([regionChromo, currStart, blStart])
-					currStart = blEnd
-
-				if (pos == (len(overlappedBL)-1)) and (blEnd < regionEnd):
-					if blEnd == regionEnd:
-						break
-					regionsWoBL.append([regionChromo, blEnd, regionEnd])
-
-	# check if all chromosomes in the REGIONS in bigwig files
-	finalRegions = ChromoRegionSet()
-	with pyBigWig.open(CTRLBW_NAMES[0]) as bw:
-		for region in regionsWoBL:
-			chromo, start, end = region
-
-			chromoLen = bw.chroms(chromo)
-			if chromoLen is None or chromoLen <= start:
-				continue
-
-			if end > chromoLen:
-				end = chromoLen
-
-			finalRegions.addRegion(ChromoRegion(chromo, start, end))
-
-	REGIONS = finalRegions
-
+	return finalRegionSet
 
 def setFilterCriteria(minFrag):
 	global FILTERVALUE

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ clean:
 	-rm CRADLE/**/*.c
 
 dist: $(PYTHON_FILES) $(CYTHON_FILES)
-	if [[ -z $$(pip list | grep -e "^build\s") ]]; then pip install build; fi
+	if [ -z $$(pip list | grep -e "^build\s") ]; then pip install build; fi
 	python -m build
 
 install: dist

--- a/tests/CorrectBias/vari_test.py
+++ b/tests/CorrectBias/vari_test.py
@@ -1,0 +1,41 @@
+import pytest
+import pyximport; pyximport.install()
+
+from CRADLE.CorrectBias.vari import setAnlaysisRegion
+from CRADLE.correctbiasutils import ChromoRegion, ChromoRegionSet
+from tests.mocks.BigWig import BigWig
+
+@pytest.mark.parametrize("regionSet1, blacklistRegionSet, bigWig, result", [
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 100)]),
+		ChromoRegionSet([ChromoRegion("chr1", 20, 200)]),
+		BigWig({'chr1': [float(1) for _ in range(400)]}),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 20)])
+	),
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 300), ChromoRegion("chr1", 30, 100)]),
+		ChromoRegionSet([ChromoRegion("chr1", 20, 200)]),
+		BigWig({'chr1': [float(1) for _ in range(150)]}),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 20)])
+	),
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 300), ChromoRegion("chr1", 30, 100)]),
+		ChromoRegionSet([ChromoRegion("chr1", 20, 40), ChromoRegion("chr1", 50, 60)]),
+		BigWig({'chr1': [float(1) for _ in range(200)]}),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 20), ChromoRegion("chr1", 40, 50), ChromoRegion("chr1", 60, 200)])
+	),
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 300), ChromoRegion("chr2", 30, 100)]),
+		ChromoRegionSet([ChromoRegion("chr1", 20, 200)]),
+		BigWig({'chr1': [float(1) for _ in range(400)]}),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 20), ChromoRegion("chr1", 200, 300)])
+	),
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 300), ChromoRegion("chr2", 30, 100)]),
+		None,
+		BigWig({'chr1': [float(1) for _ in range(400)]}),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 300),])
+	),
+])
+def testSetAnlaysisRegion(regionSet1, blacklistRegionSet, bigWig, result):
+	assert setAnlaysisRegion(regionSet1, blacklistRegionSet, bigWig) == result

--- a/tests/CorrectBiasStored/vari_test.py
+++ b/tests/CorrectBiasStored/vari_test.py
@@ -1,0 +1,41 @@
+import pytest
+import pyximport; pyximport.install()
+
+from CRADLE.CorrectBiasStored.vari import setAnlaysisRegion
+from CRADLE.correctbiasutils import ChromoRegion, ChromoRegionSet
+from tests.mocks.BigWig import BigWig
+
+@pytest.mark.parametrize("regionSet1, blacklistRegionSet, bigWig, result", [
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 100)]),
+		ChromoRegionSet([ChromoRegion("chr1", 20, 200)]),
+		BigWig({'chr1': [float(1) for _ in range(400)]}),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 20)])
+	),
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 300), ChromoRegion("chr1", 30, 100)]),
+		ChromoRegionSet([ChromoRegion("chr1", 20, 200)]),
+		BigWig({'chr1': [float(1) for _ in range(150)]}),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 20)])
+	),
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 300), ChromoRegion("chr1", 30, 100)]),
+		ChromoRegionSet([ChromoRegion("chr1", 20, 40), ChromoRegion("chr1", 50, 60)]),
+		BigWig({'chr1': [float(1) for _ in range(200)]}),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 20), ChromoRegion("chr1", 40, 50), ChromoRegion("chr1", 60, 200)])
+	),
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 300), ChromoRegion("chr2", 30, 100)]),
+		ChromoRegionSet([ChromoRegion("chr1", 20, 200)]),
+		BigWig({'chr1': [float(1) for _ in range(400)]}),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 20), ChromoRegion("chr1", 200, 300)])
+	),
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 300), ChromoRegion("chr2", 30, 100)]),
+		None,
+		BigWig({'chr1': [float(1) for _ in range(400)]}),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 300),])
+	),
+])
+def testSetAnlaysisRegion(regionSet1, blacklistRegionSet, bigWig, result):
+	assert setAnlaysisRegion(regionSet1, blacklistRegionSet, bigWig) == result

--- a/tests/correctbiasutils/chromoregion_test.py
+++ b/tests/correctbiasutils/chromoregion_test.py
@@ -1,0 +1,91 @@
+import pytest
+
+from CRADLE.correctbiasutils import ChromoRegion, ChromoRegionMergeException
+
+@pytest.mark.parametrize("region1,region2,result", [
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr2", 90, 200), False),
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 90, 200), True),
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 100, 200), True),
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 101, 200), False),
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 200, 300), False),
+	(ChromoRegion("chr2", 90, 200), ChromoRegion("chr1", 10, 100), False),
+	(ChromoRegion("chr1", 90, 200), ChromoRegion("chr1", 10, 100), True),
+	(ChromoRegion("chr1", 100, 200), ChromoRegion("chr1", 10, 100), True),
+	(ChromoRegion("chr1", 101, 200), ChromoRegion("chr1", 10, 100), False),
+	(ChromoRegion("chr1", 200, 300), ChromoRegion("chr1", 10, 100), False),
+])
+def testChromoRegionContiguous(region1, region2, result):
+	assert region1.contiguousWith(region2) == result
+
+@pytest.mark.parametrize("region,length", [
+	(ChromoRegion("chr1", 10, 100), 90),
+	(ChromoRegion("chr2", 90, 200), 110),
+])
+def testChromoRegionLength(region, length):
+	assert len(region) == length
+
+@pytest.mark.parametrize("region1,region2,result", [
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 10, 100), True),
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr2", 10, 100), False),
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 90, 200), False),
+])
+def testChromoRegionEqual(region1, region2, result):
+	assert (region1 == region2) == result
+
+@pytest.mark.parametrize("region1,region2,result", [
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 10, 100), False),
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr2", 10, 100), True),
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 90, 200), True),
+	(ChromoRegion("chr2", 10, 100), ChromoRegion("chr1", 10, 100), False),
+	(ChromoRegion("chr1", 90, 200), ChromoRegion("chr1", 10, 100), False),
+	(ChromoRegion("chr1", 90, 200), ChromoRegion("chr1", 100, 200), True),
+	(ChromoRegion("chr1", 100, 200), ChromoRegion("chr1", 90, 200), False),
+])
+def testChromoRegionLessThan(region1, region2, result):
+	assert (region1 < region2) == result
+
+@pytest.mark.parametrize("region1,region2,result,exception", [
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 10, 100), None),
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 50, 100), ChromoRegion("chr1", 10, 100), None),
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 50, 200), ChromoRegion("chr1", 10, 200), None),
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 50, 200), ChromoRegion("chr1", 10, 200), None),
+	(ChromoRegion("chr1", 50, 100), ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 10, 100), None),
+	(ChromoRegion("chr1", 50, 200), ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 10, 200), None),
+	(ChromoRegion("chr1", 50, 200), ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 10, 200), None),
+	(ChromoRegion("chr1", 50, 200), ChromoRegion("chr2", 10, 100), None, ChromoRegionMergeException),
+	(ChromoRegion("chr1", 50, 200), ChromoRegion("chr2", 10, 30), None, ChromoRegionMergeException),
+	(ChromoRegion("chr1", 50, 200), ChromoRegion("chr1", 10, 30), None, ChromoRegionMergeException),
+	(ChromoRegion("chr1", 10, 30), ChromoRegion("chr1", 50, 200), None, ChromoRegionMergeException),
+])
+def testChromoRegionAdd(region1, region2, result, exception):
+	if exception is None:
+		assert region1 + region2 == result
+	else:
+		with pytest.raises(exception):
+			_ = region1 + region2
+
+@pytest.mark.parametrize("region1,region2,result", [
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 1, 101), []),
+	(ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 90), [ChromoRegion("chr1", 10, 20), ChromoRegion("chr1", 90, 100)]),
+	(ChromoRegion("chr1", 50, 100), ChromoRegion("chr1", 10, 60), [ChromoRegion("chr1", 60, 100)]),
+	(ChromoRegion("chr1", 50, 100), ChromoRegion("chr1", 60, 150), [ChromoRegion("chr1", 50, 60)]),
+	(ChromoRegion("chr1", 50, 100), ChromoRegion("chr1", 1, 50), [ChromoRegion("chr1", 50, 100)]),
+	(ChromoRegion("chr1", 50, 100), ChromoRegion("chr1", 100, 150), [ChromoRegion("chr1", 50, 100)]),
+	(ChromoRegion("chr1", 50, 100), ChromoRegion("chr2", 10, 80), [ChromoRegion("chr1", 50, 100)]),
+])
+def testChromoRegionSub(region1, region2, result):
+	assert region1 - region2 == result
+
+@pytest.mark.parametrize("region, newEnd, result, exception", [
+	(ChromoRegion("chr1", 10, 100), 90, ChromoRegion("chr1", 10, 90), None),
+	(ChromoRegion("chr1", 10, 100), 100, ChromoRegion("chr1", 10, 100), None),
+	(ChromoRegion("chr1", 10, 100), 110, ChromoRegion("chr1", 10, 110), None),
+	(ChromoRegion("chr1", 10, 100), 9, None, AssertionError),
+])
+def testChromoRegionSetEnd(region, newEnd, result, exception):
+	if exception is None:
+		region.end = newEnd
+		assert region == result
+	else:
+		with pytest.raises(exception):
+			region.end = newEnd

--- a/tests/correctbiasutils/chromoregionset_test.py
+++ b/tests/correctbiasutils/chromoregionset_test.py
@@ -1,0 +1,94 @@
+import pytest
+
+from CRADLE.correctbiasutils import ChromoRegion, ChromoRegionSet
+
+@pytest.mark.parametrize("regionSet, region, result", [
+	(ChromoRegionSet(), ChromoRegion("chr1", 10, 100), ChromoRegionSet([ChromoRegion("chr1", 10, 100)])),
+	(ChromoRegionSet([ChromoRegion("chr1", 10, 100)]), ChromoRegion("chr1", 110, 200), ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 110, 200)]))
+])
+def testChromoRegionSetAddRegion(regionSet, region, result):
+	regionSet.addRegion(region)
+	assert regionSet == result
+
+@pytest.mark.parametrize("regionSet, result", [
+	(ChromoRegionSet([ChromoRegion("chr1", 10, 100)]), ChromoRegionSet([ChromoRegion("chr1", 10, 100)])),
+	(ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 200)]), ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 200)])),
+	(ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr1", 10, 100)]), ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 200)])),
+	(ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 100)]), ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 100)])),
+	(ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 100), ChromoRegion("chr1", 10, 100)]), ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 100)])),
+])
+def testChromoRegionSetSortRegions(regionSet, result):
+	regionSet.sortRegions()
+	assert regionSet == result
+
+@pytest.mark.parametrize("regionSet, result", [
+	(ChromoRegionSet([ChromoRegion("chr1", 10, 100)]), ChromoRegionSet([ChromoRegion("chr1", 10, 100)])),
+	(ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 200)]), ChromoRegionSet([ChromoRegion("chr1", 10, 200)])),
+	(ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 100)]), ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 100)])),
+	(ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 100), ChromoRegion("chr1", 10, 100)]), ChromoRegionSet([ChromoRegion("chr1", 10, 200), ChromoRegion("chr2", 10, 100)])),
+	(ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 100), ChromoRegion("chr1", 10, 100), ChromoRegion("chr2", 10, 100)]), ChromoRegionSet([ChromoRegion("chr1", 10, 200), ChromoRegion("chr2", 10, 100)])),
+	(ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 100), ChromoRegion("chr1", 10, 100), ChromoRegion("chr2", 100, 200)]), ChromoRegionSet([ChromoRegion("chr1", 10, 200), ChromoRegion("chr2", 10, 200)])),
+	(ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 100), ChromoRegion("chr1", 10, 100), ChromoRegion("chr2", 101, 200)]), ChromoRegionSet([ChromoRegion("chr1", 10, 200), ChromoRegion("chr2", 10, 100), ChromoRegion("chr2", 101, 200)])),
+])
+def testChromoRegionMergeRegions(regionSet, result):
+	regionSet.mergeRegions()
+	assert regionSet == result
+
+@pytest.mark.parametrize("regionSet1, regionSet2, result", [
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr2", 10, 200)]),
+		ChromoRegionSet([ChromoRegion("chr1", 20, 200)]),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 200)])
+	),
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 10, 100)]),
+		ChromoRegionSet([ChromoRegion("chr1", 20, 200)]),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 200), ChromoRegion("chr1", 10, 100)])
+	)
+])
+def testChromoRegionSetAdd(regionSet1, regionSet2, result):
+	assert (regionSet1 + regionSet2) == result
+
+@pytest.mark.parametrize("regionSet1, regionSet2, result", [
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 100)]),
+		ChromoRegionSet([ChromoRegion("chr1", 20, 200)]),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 20)])
+	),
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 300), ChromoRegion("chr1", 30, 100)]),
+		ChromoRegionSet([ChromoRegion("chr1", 20, 200)]),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 20), ChromoRegion("chr1", 200, 300)])
+	),
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 300), ChromoRegion("chr1", 30, 100)]),
+		ChromoRegionSet([ChromoRegion("chr1", 20, 40), ChromoRegion("chr1", 50, 60)]),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 20), ChromoRegion("chr1", 40, 50), ChromoRegion("chr1", 60, 300), ChromoRegion("chr1", 40, 50), ChromoRegion("chr1", 60, 100)])
+	),
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 300), ChromoRegion("chr2", 30, 100)]),
+		ChromoRegionSet([ChromoRegion("chr1", 20, 200)]),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 20), ChromoRegion("chr1", 200, 300), ChromoRegion("chr2", 30, 100)])
+	),
+])
+def testChromoRegionSetSubtract(regionSet1, regionSet2, result):
+    assert (regionSet1 - regionSet2) == result
+
+@pytest.mark.parametrize("regionSet, length", [
+	(ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 110, 200)]), 2),
+	(ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 110, 200), ChromoRegion("chr2", 110, 200)]), 3)
+])
+def testChromoRegionSetLength(regionSet, length):
+	assert len(regionSet) == length
+
+@pytest.mark.parametrize("regionSet1, regionSet2, result", [
+	(ChromoRegionSet([ChromoRegion("chr1", 10, 100)]), ChromoRegionSet([ChromoRegion("chr1", 10, 100)]), True),
+	(ChromoRegionSet([ChromoRegion("chr1", 10, 100)]), ChromoRegionSet([ChromoRegion("chr2", 10, 100)]), False),
+	(ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 200)]), ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 200)]), True),
+	(ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 200)]), ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr1", 10, 100)]), True),
+	(ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr2", 20, 200)]), ChromoRegionSet([ChromoRegion("chr2", 20, 200), ChromoRegion("chr1", 10, 100)]), True),
+	(ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 200)]), ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr2", 20, 200)]), False),
+
+])
+def testChromoRegionSetEqual(regionSet1, regionSet2, result):
+	assert (regionSet1 == regionSet2) == result

--- a/tests/mocks/BigWig.py
+++ b/tests/mocks/BigWig.py
@@ -26,6 +26,15 @@ class BigWig:
 		else:
 			return data
 
+	def chroms(self, chrom=None):
+		if chrom is None:
+			return {k: len(self.data[k]) for k in self.data}
+
+		if chrom in self.data:
+			return len(self.data[chrom])
+
+		return None
+
 	def addEntries(self, chroms, starts, ends=None, values=None):
 		'''This is not an exact replica of pyBigWig's behavior. That
 		version of addEntries has some more arguments and accepts inputs

--- a/tests/mocks/BigWig_test.py
+++ b/tests/mocks/BigWig_test.py
@@ -18,7 +18,18 @@ def testAddHeader():
 ])
 def testValues(data, location, numpy, result):
 	bw = BigWig(data)
-	assert np.array_equal(bw.values(location[0], location[1], location[2], numpy), result, equal_nan=True)
+	assert np.array_equal(bw.values(*location, numpy), result, equal_nan=True)
+
+@pytest.mark.parametrize("bigwig, chrom, result", [
+	(BigWig({'chr1': [np.nan, np.nan, 0., 1., 1., 5., 6., 6., 0., 7., 8., 10.]}), 'chr1', 12),
+	(BigWig({'chr1': [np.nan, np.nan, 0., 1., 1., 5., 6., 6., 0., 7., 8., 10.]}), 'chr2', None),
+	(BigWig({'chr1': [np.nan, np.nan, 0., 1., 1., 5., 6., 6., 0., 7., 8., 10.]}), None, {'chr1': 12}),
+])
+def testChroms(bigwig, chrom, result):
+	if chrom is None:
+		assert bigwig.chroms() == result
+	else:
+		assert bigwig.chroms(chrom) == result
 
 @pytest.mark.parametrize("data,chroms,starts,ends,values,results", [
 	(


### PR DESCRIPTION
Some code, like the region loading code in vari.py, can be simplified and
clarified by breaking it up into parts (merge regions, subtract regions, etc.)
and moving those into ChromoRegion* methods.

This made the ChromoRegion* classes bigger and a bit more complex, so I've added
reasonably comprehensive tests for them.

I also decided to add type annotations to demonstrate that. You can check the types by running

    mypy CRADLE/correctbiasutils

(after installing mypy with `pip install mypy`)

Finally, I did some refactoring of CRADLE.CorrectBias*.vari.setAnlaysisRegion so setAnalysisRegion
can be tested, and added tests.