### PR TITLE
Fixes Memory and BW Region Order Problems

### DIFF
--- a/CRADLE/CorrectBias/correctBias.py
+++ b/CRADLE/CorrectBias/correctBias.py
@@ -162,7 +162,7 @@ def run(args):
 	)
 	vari.HIGHRC = rc90Percentile
 
-	trainingSetMeta = utils.process(min(11, commonVari.NUMPROCESS), utils.fillTrainingSetMeta, trainingSetMeta)
+	trainingSetMeta = utils.process(min(11, commonVari.NUMPROCESS), utils.fillTrainingSetMeta, trainingSetMeta, context="fork")
 
 	print("-- RUNNING TIME of getting trainSetMeta : %s hour(s)" % ((time.time()-startTime)/3600) )
 

--- a/CRADLE/correctbiasutils/__init__.py
+++ b/CRADLE/correctbiasutils/__init__.py
@@ -7,6 +7,7 @@ import math
 import multiprocessing
 import os
 import os.path
+import struct
 import tempfile
 import matplotlib # type: ignore
 import matplotlib.pyplot as plt # type: ignore
@@ -24,6 +25,8 @@ matplotlib.use('Agg')
 TRAINING_BIN_SIZE = 1_000
 SCATTERPLOT_SAMPLE_COUNT = 10_000
 SONICATION_SHEAR_BIAS_OFFSET = 2
+
+CORRECTED_RC_TEMP_FILE_STRUCT_FORMAT = "@5sLLf"
 
 # Used to adjust coordinates between 0 and 1-based systems.
 START_INDEX_ADJUSTMENT = 1
@@ -250,9 +253,9 @@ class ChromoRegionSet:
 
 		return regionSet
 
-def process(poolSize, function, argumentLists):
-	pool = multiprocessing.Pool(poolSize)
-	results = pool.starmap_async(function, argumentLists).get()
+def process(poolSize, function, argumentLists, context="spawn"):
+	pool = multiprocessing.get_context(context).Pool(poolSize)
+	results = pool.starmap(function, argumentLists)
 	pool.close()
 	pool.join()
 
@@ -263,7 +266,7 @@ def getResultBWHeader(regions, ctrlBWName):
 		resultBWHeader = []
 		for chromo in regions.chromos:
 			chromoSize = bwFile.chroms(chromo)
-			resultBWHeader.append( (chromo, chromoSize) )
+			resultBWHeader.append((chromo, chromoSize))
 
 	return resultBWHeader
 
@@ -318,9 +321,9 @@ def mergeBWFiles(outputDir, header, tempFiles, ctrlBWNames, experiBWNames):
 
 	jobList = []
 	for i, ctrlFile in enumerate(ctrlBWNames):
-		jobList.append([ctrlFiles[i], header, outputBWFile(outputDir, ctrlFile)])
+		jobList.append((ctrlFiles[i], header, outputBWFile(outputDir, ctrlFile)))
 	for i, experiFile in enumerate(experiBWNames):
-		jobList.append([experiFiles[i], header, outputBWFile(outputDir, experiFile)])
+		jobList.append((experiFiles[i], header, outputBWFile(outputDir, experiFile)))
 
 	return process(len(ctrlBWNames) + len(experiBWNames), mergeCorrectedFilesToBW, jobList)
 
@@ -331,18 +334,23 @@ def outputBWFile(outputDir, filename):
 def mergeCorrectedFilesToBW(tempFiles, bwHeader, signalBWName):
 	signalBW = pyBigWig.open(signalBWName, "w")
 	signalBW.addHeader(bwHeader)
+	dataReadSize = struct.calcsize(CORRECTED_RC_TEMP_FILE_STRUCT_FORMAT) * 1_000_000 # a somewhat arbitrary choice
 
 	for tempFile in tempFiles:
 		with open(tempFile, 'rb') as dataFile:
-			correctedReadCounts = marshal.load(dataFile)
-
-		for counts in correctedReadCounts:
-			chromo, readCounts = counts
-			if readCounts is None:
-				continue
-
-			sectionCount, starts, ends, values = readCounts
-			signalBW.addEntries([chromo] * sectionCount, starts, ends=ends, values=values)
+			data = dataFile.read(dataReadSize)
+			while data != b'':
+				chromos = []
+				starts = []
+				ends = []
+				values = []
+				for chromo, start, end, value in struct.iter_unpack(CORRECTED_RC_TEMP_FILE_STRUCT_FORMAT, data):
+					chromos.append(chromo.decode('utf-8').strip())
+					starts.append(start)
+					ends.append(end)
+					values.append(value)
+				signalBW.addEntries(chromos, starts, ends=ends, values=values)
+				data = dataFile.read(dataReadSize)
 
 		os.remove(tempFile)
 
@@ -375,9 +383,9 @@ def genNormalizedObBWs(outputDir, header, regions, ctrlBWNames, ctrlScaler, expe
 
 	jobList = []
 	for i, ctrlBWName in enumerate(ctrlBWNames[1:], start=1):
-		jobList.append([header, float(ctrlScaler[i]), regions, ctrlBWName, outputNormalizedBWFile(outputDir, ctrlBWName)])
+		jobList.append((header, float(ctrlScaler[i]), regions, ctrlBWName, outputNormalizedBWFile(outputDir, ctrlBWName)))
 	for i, experiBWName in enumerate(experiBWNames):
-		jobList.append([header, float(experiScaler[i]), regions, experiBWName, outputNormalizedBWFile(outputDir, experiBWName)])
+		jobList.append((header, float(experiScaler[i]), regions, experiBWName, outputNormalizedBWFile(outputDir, experiBWName)))
 
 
 	return process(len(ctrlBWNames) + len(experiBWNames) - 1, generateNormalizedObBWs, jobList)
@@ -411,7 +419,6 @@ def _generateNormalizedObBWs(bwHeader, scaler, regions, observedBW, normObBW):
 		values = values / scaler
 
 		coalescedSectionCount, startEntries, endEntries, valueEntries = coalesceSections(starts, values)
-
 		normObBW.addEntries([region.chromo] * coalescedSectionCount, startEntries, ends=endEntries, values=valueEntries)
 
 def getReadCounts(trainingSet, fileName):
@@ -436,7 +443,7 @@ def getScalerTasks(trainingSet, observedReadCounts, ctrlBWNames, experiBWNames):
 			bwName = ctrlBWNames[i]
 		else:
 			bwName = experiBWNames[i - ctrlBWCount]
-		tasks.append([trainingSet, observedReadCounts, bwName])
+		tasks.append((trainingSet, observedReadCounts, bwName))
 
 	return tasks
 
@@ -559,17 +566,17 @@ def getCandidateTrainingSet(rcPercentile, regions, ctrlBWName, outputDir):
 	for i in range(5):
 		rc1 = int(np.percentile(meanRC, int(rcPercentile[i])))
 		rc2 = int(np.percentile(meanRC, int(rcPercentile[i+1])))
-		temp = [rc1, rc2, trainingRegionNum1, regions, ctrlBWName, outputDir, rc90Percentile, rc99Percentile]
+		temp = (rc1, rc2, trainingRegionNum1, regions, ctrlBWName, outputDir, rc90Percentile, rc99Percentile)
 		trainingSetMeta.append(temp)  ## RC criteria1(down), RC criteria2(up), # of bases, candidate regions
 
 	for i in range(5, 11):
 		rc1 = int(np.percentile(meanRC, int(rcPercentile[i])))
 		rc2 = int(np.percentile(meanRC, int(rcPercentile[i+1])))
 		if i == 10:
-			temp = [rc1, rc2, 3*trainingRegionNum2, regions, ctrlBWName, outputDir, rc90Percentile, rc99Percentile]
+			temp = (rc1, rc2, 3*trainingRegionNum2, regions, ctrlBWName, outputDir, rc90Percentile, rc99Percentile)
 			rc99Percentile = rc1
 		else:
-			temp = [rc1, rc2, trainingRegionNum2, regions, ctrlBWName, outputDir, rc90Percentile, rc99Percentile] # RC criteria1(down), RC criteria2(up), # of bases, candidate regions
+			temp = (rc1, rc2, trainingRegionNum2, regions, ctrlBWName, outputDir, rc90Percentile, rc99Percentile) # RC criteria1(down), RC criteria2(up), # of bases, candidate regions
 		if i == 5:
 			rc90Percentile = rc1
 
@@ -584,52 +591,7 @@ def fillTrainingSetMeta(downLimit, upLimit, trainingRegionNum, regions, ctrlBWNa
 	numOfCandiRegion = 0
 
 	resultFile = tempfile.NamedTemporaryFile(mode="w+t", suffix=".txt", dir=outputDir, delete=False)
-	'''
-	if downLimit == rc99Percentile:
-		result = []
 
-		for region in regions:
-			regionChromo = region[0]
-			regionStart = int(region[1])
-			regionEnd = int(region[2])
-
-			numBin = int( (regionEnd - regionStart) / TRAINING_BIN_SIZE )
-			if numBin == 0:
-				numBin = 1
-				meanValue = np.array(ctrlBW.stats(regionChromo, regionStart, regionEnd, nBins=numBin, type="mean"))[0]
-
-				if meanValue is None:
-					continue
-
-				if (meanValue >= downLimit) and (meanValue < upLimit):
-					result.append([regionChromo, regionStart, regionEnd, meanValue])
-
-			else:
-				regionEnd = numBin * TRAINING_BIN_SIZE + regionStart
-				meanValues = np.array(ctrlBW.stats(regionChromo, regionStart, regionEnd, nBins=numBin, type="mean"))
-				pos = np.array(list(range(0, numBin))) * TRAINING_BIN_SIZE + regionStart
-
-				idx = np.where(meanValues != None)
-				meanValues = meanValues[idx]
-				pos = pos[idx]
-
-				idx = np.where((meanValues >= downLimit) & (meanValues < upLimit))
-				start = pos[idx]
-				end = start + TRAINING_BIN_SIZE
-				meanValues = meanValues[idx]
-				chromoArray = [regionChromo] * len(start)
-				result.extend(np.column_stack((chromoArray, start, end, meanValues)).tolist())
-
-		if len(result) == 0:
-			return None
-
-		result = np.array(result)
-		result = result[result[:,3].astype(float).astype(int).argsort()][:,0:3].tolist()
-
-		numOfCandiRegion = len(result)
-		for i in range(len(result)):
-			resultFile.write('\t'.join([str(x) for x in result[i]]) + "\n")
-	'''
 	fileBuffer = io.StringIO()
 	for region in regions:
 		numBin = len(region) // TRAINING_BIN_SIZE
@@ -671,12 +633,14 @@ def fillTrainingSetMeta(downLimit, upLimit, trainingRegionNum, regions, ctrlBWNa
 	resultFile.close()
 	fileBuffer.close()
 
-	if numOfCandiRegion != 0:
-		resultLine.extend([numOfCandiRegion, resultFile.name])
-		return resultLine
+	if numOfCandiRegion == 0:
+		os.remove(resultFile.name)
+		return None
 
-	os.remove(resultFile.name)
-	return None
+	resultLine.extend([numOfCandiRegion, resultFile.name])
+	return resultLine
+
+
 
 def alignCoordinatesToCovariateFileBoundaries(genome, trainingSet, fragLen):
 	newTrainingSet = ChromoRegionSet()

--- a/CRADLE/correctbiasutils/cython.pyx
+++ b/CRADLE/correctbiasutils/cython.pyx
@@ -108,8 +108,12 @@ cpdef coalesceSections(starts, values, analysisEnd=None, stepSize=1):
 	values = values.astype(int)
 	numIdx = values.size
 
+	startEntries = []
+	endEntries = []
+	valueEntries = []
+
 	if numIdx == 0:
-		return 0, [], [], []
+		return 0, startEntries, endEntries, valueEntries
 
 	startsView = starts
 	valuesView = values
@@ -117,10 +121,6 @@ cpdef coalesceSections(starts, values, analysisEnd=None, stepSize=1):
 	currStart = startsView[0]
 	currValue = valuesView[0]
 	currEnd = currStart + cStepSize
-
-	startEntries = []
-	endEntries = []
-	valueEntries = []
 
 	coalescedSectionCount = 1
 	i = 1

--- a/tests/correctbiasutils/chromoregionset_test.py
+++ b/tests/correctbiasutils/chromoregionset_test.py
@@ -16,10 +16,14 @@ def testChromoRegionSetAddRegion(regionSet, region, result):
 	(ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr1", 10, 100)]), ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 200)])),
 	(ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 100)]), ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 100)])),
 	(ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 100), ChromoRegion("chr1", 10, 100)]), ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 10, 100)])),
+	(ChromoRegionSet([ChromoRegion("chr10", 10, 100), ChromoRegion("chr2", 20, 200), ChromoRegion("chrX", 20, 200), ChromoRegion("chr1", 20, 200)]), ChromoRegionSet([ChromoRegion("chr1", 20, 200), ChromoRegion("chr2", 20, 200), ChromoRegion("chr10", 10, 100), ChromoRegion("chrX", 20, 200)])),
 ])
 def testChromoRegionSetSortRegions(regionSet, result):
 	regionSet.sortRegions()
-	assert regionSet == result
+
+	# regionSet == result sorts as part of the comparison, so we have to compare the region lists directly
+	assert regionSet.regions == result.regions
+	assert regionSet.chromos == result.chromos
 
 @pytest.mark.parametrize("regionSet, result", [
 	(ChromoRegionSet([ChromoRegion("chr1", 10, 100)]), ChromoRegionSet([ChromoRegion("chr1", 10, 100)])),
@@ -44,6 +48,11 @@ def testChromoRegionMergeRegions(regionSet, result):
 		ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 10, 100)]),
 		ChromoRegionSet([ChromoRegion("chr1", 20, 200)]),
 		ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 20, 200), ChromoRegion("chr1", 10, 100)])
+	),
+	(
+		ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 10, 100)]),
+		ChromoRegionSet([ChromoRegion("chr2", 20, 200)]),
+		ChromoRegionSet([ChromoRegion("chr1", 10, 100), ChromoRegion("chr1", 10, 100), ChromoRegion("chr2", 20, 200)])
 	)
 ])
 def testChromoRegionSetAdd(regionSet1, regionSet2, result):

--- a/tests/correctbiasutils/coalescesections_test.py
+++ b/tests/correctbiasutils/coalescesections_test.py
@@ -1,3 +1,5 @@
+import array
+
 import numpy as np
 import pytest
 import pyximport; pyximport.install()
@@ -62,6 +64,6 @@ def testCoalesceSections(starts, values, analysisEnd, stepSize, sectionCount, st
 	values = values[idx]
 	result =  coalesceSections(starts, values, analysisEnd, stepSize)
 	assert result[0] == sectionCount
-	assert result[1] == startEntries
-	assert result[2] == endEntries
-	assert result[3] == valueEntries
+	assert result[1] == array.array('L', startEntries)
+	assert result[2] == array.array('L', endEntries)
+	assert result[3] == array.array('f', valueEntries)

--- a/tests/correctbiasutils/coalescesections_test.py
+++ b/tests/correctbiasutils/coalescesections_test.py
@@ -1,5 +1,3 @@
-import array
-
 import numpy as np
 import pytest
 import pyximport; pyximport.install()
@@ -64,6 +62,6 @@ def testCoalesceSections(starts, values, analysisEnd, stepSize, sectionCount, st
 	values = values[idx]
 	result =  coalesceSections(starts, values, analysisEnd, stepSize)
 	assert result[0] == sectionCount
-	assert result[1] == array.array('L', startEntries)
-	assert result[2] == array.array('L', endEntries)
-	assert result[3] == array.array('f', valueEntries)
+	assert result[1] == startEntries
+	assert result[2] == endEntries
+	assert result[3] == valueEntries

--- a/tests/correctbiasutils/init_test.py
+++ b/tests/correctbiasutils/init_test.py
@@ -106,7 +106,7 @@ def testGetReadCounts(trainingSets, bwFile, result):
 ])
 def testGetScalerTasks(trainingSets, observedReadCounts, ctrlBWNames, experiBWNames, resultBWList):
 	result = utils.getScalerTasks(trainingSets, observedReadCounts, ctrlBWNames, experiBWNames)
-	expectedResult = [[trainingSets, observedReadCounts, fileName] for fileName in resultBWList]
+	expectedResult = [(trainingSets, observedReadCounts, fileName) for fileName in resultBWList]
 	assert result == expectedResult
 
 @pytest.mark.parametrize("bwFileName,binCount,chromo,start,end,result", [


### PR DESCRIPTION
### Fixes a bigwig data order issue
This bigwig issue was that the order of the chromosomes in the header created
for the new bigwig files did not match the order that data was added to the
bigwig files. The chromosome data used to create the header was an unordered set,
so the order was more-or-less random.

The fix is to use a list instead of a set. The list gets updated when the set is added to or sorted.
That's not exactly true -- the list update is deferred until it's the list is needed.

### Fixes a memory problem
A change was made correctReadCounts a while ago that stored the new read
count data until it could be done in a single write. As data sets get bigger
and more regions are covered this became untenable -- memory usage shot way,
way up.

These change moves back to "write data immediately" model. Instead of writing
a bed file, though, a binary format is used. It's more compact and hopefully
faster to read and write than the text-based .bed format.

Some other changes were made to also try regain some of the speed:
* Numbers were given cython types.
* The multiprocessing helper, correctbiasutils.process, was
changed to use a better way of creating new processes.
* python lists of numbers were swapped out for arrays, which are more performant.