### PR TITLE
Adds explicit "slots" to classes

### DIFF
--- a/CRADLE/CorrectBiasStored/vari.py
+++ b/CRADLE/CorrectBiasStored/vari.py
@@ -7,6 +7,8 @@ def setGlobalVariables(args):
 	setCovariDir(args.biasType, args.covariDir, args.genome)
 
 class StoredCovariates:
+	__slots__ = ["directory", "name", "fragLen", "order", "selected", "num"]
+
 	def __init__(self, biasTypes, directory):
 		self.directory = directory.rstrip('/')
 		self.name = self.directory.split('/')[-1]

--- a/CRADLE/correctbiasutils/__init__.py
+++ b/CRADLE/correctbiasutils/__init__.py
@@ -35,13 +35,15 @@ class ChromoRegionMergeException(Exception):
 	pass
 
 class ChromoRegion:
+	__slots__ = ["chromo", "start", "_end", "_length"]
+
 	"""Describes a Chromosome region. Index is 0-based and half-closed"""
 	def __init__(self, chromo: str, start: int, end: int) -> None:
 		assert start <= end
 		self.chromo = chromo
 		self.start = start
 		self._end = end
-		self._length = self._end - self.start
+		self._length = end - start
 
 	@property
 	def end(self) -> int:
@@ -130,6 +132,8 @@ class ChromoRegion:
 
 # Not quite a set in the mathematical sense.
 class ChromoRegionSet:
+	__slots__ = ["regions", "_chromoSet", "_chromos", "cumulativeRegionSize", "_chromoOrderDirty"]
+
 	regions: list[ChromoRegion]
 	_chromoSet: set[str]
 	_chromos: list[str]


### PR DESCRIPTION
According to https://pythonspeed.com/articles/python-object-memory/ and
https://docs.python.org/3.9/reference/datamodel.html#object.__slots__
Setting __slots__ will both decrease memory usage and potentially speed up
member access. In my testing a ChromoRegion only take about half the space it
did without __slots__. As there can be a lot of ChromoRegion, this is tens, if
not hundreds of megabytes of memory savings.

There are probably similar savings per object for ChromoRegionSet and StoredCovariates
but there aren't many of those objects, so it's not as big a win.
