### PR TITLE
Factors out the code for getting chromosome ends from 2bit file

### DIFF
--- a/CRADLE/CorrectBiasStored/correctBias.py
+++ b/CRADLE/CorrectBiasStored/correctBias.py
@@ -94,8 +94,9 @@ def run(args):
 		trainSet90To99Percentile = commonVari.REGIONS
 
 	with py2bit.open(vari.GENOME) as genome:
-		trainSet90Percentile = utils.alignCoordinatesToCovariateFileBoundaries(genome, trainSet90Percentile, covariates.fragLen)
-		trainSet90To99Percentile = utils.alignCoordinatesToCovariateFileBoundaries(genome, trainSet90To99Percentile, covariates.fragLen)
+		chromoEnds = {chromo: int(genome.chroms(chromo)) for chromo in commonVari.REGIONS.chromos}
+		trainSet90Percentile = utils.alignCoordinatesToCovariateFileBoundaries(chromoEnds, trainSet90Percentile, covariates.fragLen)
+		trainSet90To99Percentile = utils.alignCoordinatesToCovariateFileBoundaries(chromoEnds, trainSet90To99Percentile, covariates.fragLen)
 
 	scatterplotSamples90Percentile = utils.getScatterplotSampleIndices(trainSet90Percentile.cumulativeRegionSize)
 	scatterplotSamples90to99Percentile = utils.getScatterplotSampleIndices(trainSet90To99Percentile.cumulativeRegionSize)
@@ -173,12 +174,13 @@ def run(args):
 	jobCount = min(len(tasks), commonVari.NUMPROCESS * len(commonVari.CTRLBW_NAMES))
 	processCount = min(len(tasks), commonVari.NUMPROCESS)
 	taskGroups = arraySplit(tasks, jobCount, fillValue=None)
+
 	print("-- Correcting read counts ....")
 	runningTime = time.time()
 	crcArgs = zip(
 		taskGroups,
 		[covariates] * jobCount,
-		[vari.GENOME] * jobCount,
+		[chromoEnds] * jobCount,
 		[commonVari.CTRLBW_NAMES] * jobCount,
 		[commonVari.CTRLSCALER] * jobCount,
 		[coefCtrl] * jobCount,

--- a/CRADLE/correctbiasutils/__init__.py
+++ b/CRADLE/correctbiasutils/__init__.py
@@ -646,11 +646,11 @@ def fillTrainingSetMeta(downLimit, upLimit, trainingRegionNum, regions, ctrlBWNa
 
 
 
-def alignCoordinatesToCovariateFileBoundaries(genome, trainingSet, fragLen):
+def alignCoordinatesToCovariateFileBoundaries(chromoEnds, trainingSet, fragLen):
 	newTrainingSet = ChromoRegionSet()
 
 	for trainingRegion in trainingSet:
-		chromoEnd = genome.chroms(trainingRegion.chromo)
+		chromoEnd = chromoEnds[trainingRegion.chromo]
 		analysisStart = trainingRegion.start
 		analysisEnd = trainingRegion.end
 

--- a/tests/correctbiasutils/init_test.py
+++ b/tests/correctbiasutils/init_test.py
@@ -5,7 +5,6 @@ import pytest
 import CRADLE.correctbiasutils as utils
 
 from tests.mocks.BigWig import BigWig
-from tests.mocks.TwoBit import TwoBit
 
 from CRADLE.correctbiasutils import ChromoRegion, ChromoRegionSet
 
@@ -129,7 +128,7 @@ def testRegionMeans(bwFileName, binCount, chromo, start, end, result):
 		assert np.allclose(utils.regionMeans(bwFile, binCount, chromo, start, end), [np.float32(x) for x in result], atol=0.00001, equal_nan=True)
 
 def testAlignCoordinatesToCovariateFileBoundaries():
-	genome = TwoBit({ "chr1": "actgtcgattcgctctcgatatagcatagctac", "chr2": "tctcgatcgctctcgcgctagagatccgag" })
+	chromoEnds = { "chr1": len("actgtcgattcgctctcgatatagcatagctac"), "chr2": len("tctcgatcgctctcgcgctagagatccgag") }
 	trainingSet = ChromoRegionSet([
 		ChromoRegion("chr1", 2, 20),
 		ChromoRegion("chr1", 4, 20),
@@ -144,7 +143,7 @@ def testAlignCoordinatesToCovariateFileBoundaries():
 		ChromoRegion("chr1", 20, 31),
 		ChromoRegion("chr2", 10, 15),
 	])
-	assert utils.alignCoordinatesToCovariateFileBoundaries(genome, trainingSet, fragLen) == results
+	assert utils.alignCoordinatesToCovariateFileBoundaries(chromoEnds, trainingSet, fragLen) == results
 
 @pytest.mark.parametrize("populationSize", [(0), (100), (1_000), (10_000), (100_000)])
 def testGetScatterplotSampleIndices(populationSize):


### PR DESCRIPTION
The only data used from the .2bit is the length of the chromosome.
Instead of opening the file and looking this up over and over, this
change allows the file to be opened just once and the data is put
into a dictionary which can be passed around.