### PR TITLE
Adds a logging decorator, factors correctBias to use it

### DIFF
--- a/CRADLE/correctbiasutils/__init__.py
+++ b/CRADLE/correctbiasutils/__init__.py
@@ -19,6 +19,7 @@ from shutil import copyfile
 from typing import Iterator, List, Type
 
 from CRADLE.correctbiasutils.cython import arraySplit, coalesceSections # type: ignore
+from CRADLE.logging import timer
 
 matplotlib.use('Agg')
 
@@ -458,6 +459,7 @@ def getScalerForEachSample(trainingSet, observedReadCounts1Values, bwFileName):
 
 	return scaler
 
+@timer("Selecting Training Sets from trainingSetMetas", 1, "m")
 def selectTrainingSetFromMeta(trainingSetMetas, rc99Percentile):
 	trainSet1 = ChromoRegionSet()
 	trainSet2 = ChromoRegionSet()
@@ -541,6 +543,8 @@ def regionMeans(bwFile, binCount, chromo, start, end):
 
 	return means
 
+
+@timer("Getting Candidate Training Sets", 1, "m")
 def getCandidateTrainingSet(rcPercentile, regions, ctrlBWName, outputDir):
 	trainRegionNum = math.pow(10, 6) / float(TRAINING_BIN_SIZE)
 

--- a/CRADLE/logging/__init__.py
+++ b/CRADLE/logging/__init__.py
@@ -1,0 +1,46 @@
+import functools
+import time
+
+
+def timer(desc="", level=0, unit="m"):
+	if level == 0:
+		prefix = "======"
+		suffix = "\n"
+		completed = "COMPLETED"
+	elif level == 1:
+		prefix = "--"
+		suffix = ""
+		completed = "Completed"
+	else:
+		prefix = "*"
+		suffix = ""
+		completed = "Completed"
+
+	unit = unit.lower()
+
+	if unit == "h":
+		timeDivisor = 3600
+		printUnit = "hr(s)"
+	elif unit == "m":
+		timeDivisor = 60
+		printUnit = "min(s)"
+	elif unit == "s":
+		timeDivisor = 1
+		printUnit = "sec(s)"
+	else:
+		raise TypeError(f"Invalid unit {unit} for `time`")
+
+	def _timer(func):
+		"""Print the runtime of the decorated function"""
+		@functools.wraps(func)
+		def wrapper_timer(*args, **kwargs):
+			print(f"{prefix}  {desc} ....")
+			startTime = time.perf_counter()    # 1
+			value = func(*args, **kwargs)
+			endTime = time.perf_counter()      # 2
+			runTime = endTime - startTime    # 3
+
+			print(f"{prefix}  {completed} {desc} .... : {runTime / timeDivisor} {printUnit}{suffix}")
+			return value
+		return wrapper_timer
+	return _timer


### PR DESCRIPTION
Instead of littering time.perf_counter() and print statements all over
the code to keep track of progress a function decorator that can handle
that code automatically has been added.

Since it is a function decorator the code that uses it had to be decomposed
into smaller functions, which isn't a bad thing. It's now easier to tell
what the steps involved in correctBias_stored are.

Sample output:
```
======  INITIALIZING PARAMETERS ....
RNG Seed: 1147029956
======  COMPLETED INITIALIZING PARAMETERS .... : 3.4828299999996774e-05 min(s)

======  SELECTING TRAINING SETS ....
--  Getting Candidate Training Sets ....
--  Completed Getting Candidate Training Sets .... : 0.00017897238333333492 min(s)
--  Filling Training Sets ....
--  Completed Filling Training Sets .... : 0.03026603753333333 min(s)
--  Selecting Training Sets from trainingSetMetas ....
--  Completed Selecting Training Sets from trainingSetMetas .... : 5.2923466666661885e-05 min(s)
======  COMPLETED SELECTING TRAINING SETS .... : 0.030499444516666672 min(s)

======  NORMALIZING READ COUNTS ....
--  Calculating Scalers ....
NORMALIZING CONSTANTS:
* CTRLBW: [1]
* EXPBW: [1.0395182419235713]

--  Completed Calculating Scalers .... : 0.023502423499999994 min(s)
--  Performing Regression ....
The order of coefficients: ['Intercept', 'MGW_shear', 'ProT_shear', 'Anneal_pcr', 'Denature_pcr', 'Map_map', 'Gquad_gquad']
* COEF_CTRL:
[[ 1.02119620e+02  4.13363095e-03  1.42272196e-03  1.04369980e-01
   9.08112085e-02  2.91661558e-04 -1.81755517e-04]]
* COEF_EXP:
[[ 1.64566348e+02  9.29160368e-03 -6.93659393e-05  1.69254236e-01
   1.50507187e-01  2.77088056e-04 -6.64082593e-05]]
* COEF_CTRL_HIGHRC:
[[ 3.33041622e+01  4.85739292e-04  1.80674765e-03  3.14296961e-02
   2.48496979e-02 -5.95324885e-06 -1.31468902e-04]]
* COEF_EXP_HIGHRC:
[[ 3.32923379e+01  4.83983500e-04  1.81003352e-03  3.14657406e-02
   2.48749683e-02 -5.64937515e-06 -1.31841005e-04]]

--  Completed Performing Regression .... : 0.04643640713333332 min(s)
======  COMPLETED NORMALIZING READ COUNTS .... : 0.06993987581666668 min(s)

======  FITTING ALL THE ANALYSIS REGIONS TO THE CORRECTION MODEL ....
--  Correcting Read Counts ....
--  Completed Correcting Read Counts .... : 0.028041953733333343 min(s)
--  Merging Temp Files ....
* Output file names:
['test_output/test_cradle_correctBias_stored_05/test_ctrl_corrected.bw', 'test_output/test_cradle_correctBias_stored_05/test_exp_corrected.bw']

--  Completed Merging Temp Files .... : 0.02692333533333334 min(s)
======  COMPLETED FITTING ALL THE ANALYSIS REGIONS TO THE CORRECTION MODEL .... : 0.055628397666666655 min(s)

======  GENERATING NORMALIZED OBSERVED BIGWIGS ....
* Nomralized observed bigwig file names:
['test_output/test_cradle_correctBias_stored_05/test_exp_normalized.bw']

======  COMPLETED GENERATING NORMALIZED OBSERVED BIGWIGS .... : 0.023476739916666656 min(s)

-- TOTAL RUNNING TIME: 0.0029930186169444444 hour(s)
```