### PR TITLE
Factors "run" function in CorrectBias/correctBias.py into multiple functions

### DIFF
--- a/CRADLE/CorrectBiasStored/correctBias.py
+++ b/CRADLE/CorrectBiasStored/correctBias.py
@@ -18,7 +18,7 @@ from CRADLE.logging import timer
 RC_PERCENTILE = [0, 20, 40, 60, 80, 90, 92, 94, 96, 98, 99, 100]
 
 
-@timer("INITIALIZING PARAMETERS", 0, "m")
+@timer("INITIALIZING PARAMETERS")
 def init(args):
 	commonVari.setGlobalVariables(args)
 	vari.setGlobalVariables(args)
@@ -32,12 +32,12 @@ def init(args):
 	return covariates, chromoEnds, resultBWHeader
 
 
-@timer("Filling Training Sets", 1, "m")
+@timer("Filling Training Sets", 1)
 def fillTrainingSets(trainingSetMeta):
 	return utils.process(min(11, commonVari.NUMPROCESS), utils.fillTrainingSetMeta, trainingSetMeta)
 
 
-@timer("SELECTING TRAINING SETS", 0, "m")
+@timer("SELECTING TRAINING SETS")
 def selectTrainingSets():
 	trainingSetMeta, rc90Percentile, rc99Percentile = utils.getCandidateTrainingSet(
 		RC_PERCENTILE,
@@ -55,7 +55,7 @@ def selectTrainingSets():
 	return trainSet90Percentile, trainSet90To99Percentile, highRC
 
 
-@timer("Calculating Scalers", 1, "m")
+@timer("Calculating Scalers", 1)
 def calculateScalers(trainSet90Percentile, trainSet90To99Percentile):
 	if commonVari.I_NORM:
 		if (len(trainSet90Percentile) == 0) or (len(trainSet90To99Percentile) == 0):
@@ -83,7 +83,7 @@ def calculateScalers(trainSet90Percentile, trainSet90To99Percentile):
 		print("")
 
 
-@timer("Performing Regression", 1, "m")
+@timer("Performing Regression", 1)
 def performRegression(covariates, chromoEnds, trainSet90Percentile, trainSet90To99Percentile ):
 	pool = multiprocessing.Pool(2)
 
@@ -161,19 +161,19 @@ def performRegression(covariates, chromoEnds, trainSet90Percentile, trainSet90To
 	return coefCtrl, coefExp, coefCtrlHighrc, coefExpHighrc
 
 
-@timer("NORMALIZING READ COUNTS", 0, "m")
+@timer("NORMALIZING READ COUNTS")
 def normalizeReadCounts(covariates, chromoEnds, trainSet90Percentile, trainSet90To99Percentile):
 	calculateScalers(trainSet90Percentile, trainSet90To99Percentile)
 
 	return performRegression(covariates, chromoEnds, trainSet90Percentile, trainSet90To99Percentile)
 
 
-@timer("Correcting Read Counts", 1, "m")
+@timer("Correcting Read Counts", 1)
 def correctReads(processCount, crcArgs):
 	return utils.process(processCount, rc.correctReadCounts, crcArgs)
 
 
-@timer("Merging Temp Files", 1, "m")
+@timer("Merging Temp Files", 1)
 def mergeTempFiles(resultBWHeader, resultMeta):
 	correctedFileNames = utils.mergeBWFiles(commonVari.OUTPUT_DIR, resultBWHeader, resultMeta, commonVari.CTRLBW_NAMES, commonVari.EXPBW_NAMES)
 
@@ -181,7 +181,7 @@ def mergeTempFiles(resultBWHeader, resultMeta):
 	print(f"{correctedFileNames}\n")
 
 
-@timer("FITTING ALL THE ANALYSIS REGIONS TO THE CORRECTION MODEL", 0, "m")
+@timer("FITTING ALL THE ANALYSIS REGIONS TO THE CORRECTION MODEL")
 def correctReadCounts(covariates, chromoEnds, coefCtrl, coefExp, coefCtrlHighrc, coefExpHighrc, highRC, resultBWHeader):
 	tasks = utils.divideGenome(commonVari.REGIONS)
 	# `vari.NUMPROCESS * len(vari.CTRLBW_NAMES)` seems like a good number of jobs
@@ -217,7 +217,7 @@ def correctReadCounts(covariates, chromoEnds, coefCtrl, coefExp, coefCtrlHighrc,
 	mergeTempFiles(resultBWHeader, resultMeta)
 
 
-@timer("GENERATING NORMALIZED OBSERVED BIGWIGS", 0, "m")
+@timer("GENERATING NORMALIZED OBSERVED BIGWIGS")
 def normalizeBigWigs(resultBWHeader):
 	normObFileNames = utils.genNormalizedObBWs(
 		commonVari.OUTPUT_DIR,


### PR DESCRIPTION
These functions are decorated with `@timer`, like CorrectBiasStored/correctBias.py
This gives some nice structure to the document and makes the timing output more standard.

Sample output:
```
********************************************************************************
* The "-faFile" argument has been deprecated in favor of "-genome" and may be  *
* removed in a future release. The functionality isn't changing, just the      *
* argument name. Please update your scripts to use "-genome".                  *
********************************************************************************

======  INITIALIZING PARAMETERS ....
RNG Seed: 1147029956
======  COMPLETED INITIALIZING PARAMETERS .... : 8.949900000000029e-05 min(s)

======  SELECTING TRAINING SETS ....
--  Getting Candidate Training Sets ....
--  Completed Getting Candidate Training Sets .... : 0.00018015576666666755 min(s)
--  Filling Training Sets ....
--  Completed Filling Training Sets .... : 0.0010629897333333342 min(s)
--  Selecting Training Sets from trainingSetMetas ....
--  Completed Selecting Training Sets from trainingSetMetas .... : 5.222728333333556e-05 min(s)
======  COMPLETED SELECTING TRAINING SETS .... : 0.001297424199999997 min(s)

--  Calculating Scalers ....
NORMALIZING CONSTANT:
CTRLBW:
[1]
EXPBW:
[1.0395182419235713]

--  Completed Calculating Scalers .... : 0.15063939385 min(s)
--  Calculating Covariates ....
--  Completed Calculating Covariates .... : 0.5323879505 min(s)
--  Calculating Covariates ....
--  Completed Calculating Covariates .... : 0.09634489940000002 min(s)
======  PERFORMING REGRESSION ....
The order of coefficients:
['Intercept', 'MGW_shear', 'ProT_shear', 'Anneal_pcr', 'Denature_pcr', 'Map_map', 'Gquad_gquad']
COEF_CTRL:
[[ 8.21228710e+01  6.74409037e-03  2.29597973e-03  1.19324614e-01
   1.03772776e-01  3.54935993e-04 -2.69264576e-04]]
COEF_EXP:
[[ 1.26804941e+02  1.15044610e-02  6.56270299e-04  1.87283588e-01
   1.65947836e-01  3.24112185e-04 -1.29222624e-04]]
COEF_CTRL_HIGHRC:
[[ 2.79778039e+01  1.37618664e-03  2.97866008e-03  3.55119542e-02
   2.92695403e-02  7.28537257e-05 -2.25462525e-04]]
COEF_EXP_HIGHRC:
[[ 2.79397927e+01  1.37448660e-03  2.98721964e-03  3.55146435e-02
   2.92723024e-02  7.36704001e-05 -2.26089553e-04]]
======  COMPLETED PERFORMING REGRESSION .... : 1.1298398991833334 min(s)

======  CORRECTING READ COUNTS ....
--  Fitting All Analysis Regions to the Correction Model ....
--  Completed Fitting All Analysis Regions to the Correction Model .... : 1.7481239345166666 min(s)
--  Merging Temp Files ....
Output File Names:
['test_cradle_correctBias/test_ctrl_corrected.bw', 'test_cradle_correctBias/test_exp_corrected.bw']
--  Completed Merging Temp Files .... : 0.003199343333333123 min(s)
======  COMPLETED CORRECTING READ COUNTS .... : 1.7513304026 min(s)

-- RUNNING TIME: 0.06104306197305556 hour(s)
```

I also removed unnecessary (because of parameter defaults) paramaters to `@timer` in
CorrectBiasStored/correctBias.py