### PR TITLE
Reverts using a common vari.py with callPeak

### DIFF
--- a/CRADLE/CallPeak/calculateRC.pyx
+++ b/CRADLE/CallPeak/calculateRC.pyx
@@ -7,7 +7,6 @@ import scipy.stats
 import statsmodels.sandbox.stats.multicomp
 
 from CRADLE.CallPeak import vari
-from CRADLE.correctbiasutils import vari as commonVari
 
 cpdef getVariance(region):
 	warnings.filterwarnings('ignore', r'All-NaN slice encountered')
@@ -23,15 +22,15 @@ cpdef getVariance(region):
 		numBin = 1
 
 	totalRC = []
-	for rep in range(commonVari.CTRLBW_NUM):
-		bw = pyBigWig.open(commonVari.CTRLBW_NAMES[rep])
+	for rep in range(vari.CTRLBW_NUM):
+		bw = pyBigWig.open(vari.CTRLBW_NAMES[rep])
 		temp = np.array(bw.stats(regionChromo, regionStart, regionEnd,  type="mean", nBins=numBin))
 		temp[np.where(temp == None)] = np.nan
 		totalRC.append(temp.tolist())
 		bw.close()
 
-	for rep in range(commonVari.EXPBW_NUM):
-		bw = pyBigWig.open(commonVari.EXPBW_NAMES[rep])
+	for rep in range(vari.EXPBW_NUM):
+		bw = pyBigWig.open(vari.EXPBW_NAMES[rep])
 		temp = np.array(bw.stats(regionChromo, regionStart, regionEnd,  type="mean", nBins=numBin))
 		temp[np.where(temp == None)] = np.nan
 		totalRC.append(temp.tolist())
@@ -59,8 +58,8 @@ cpdef getRegionCutoff(region):
 		numBin = 1
 
 	sampleRC = []
-	for rep in range(commonVari.CTRLBW_NUM):
-		bw = pyBigWig.open(commonVari.CTRLBW_NAMES[rep])
+	for rep in range(vari.CTRLBW_NUM):
+		bw = pyBigWig.open(vari.CTRLBW_NAMES[rep])
 		temp = np.array(bw.stats(regionChromo, regionStart, regionEnd,  type="mean", nBins=numBin))
 		temp[np.where(temp == None)] = np.nan
 		sampleRC.append(temp.tolist())
@@ -69,8 +68,8 @@ cpdef getRegionCutoff(region):
 	ctrlMean = np.nanmean(np.array(sampleRC), axis=0)
 
 	sampleRC = []
-	for rep in range(commonVari.EXPBW_NUM):
-		bw = pyBigWig.open(commonVari.EXPBW_NAMES[rep])
+	for rep in range(vari.EXPBW_NUM):
+		bw = pyBigWig.open(vari.EXPBW_NAMES[rep])
 		temp = np.array(bw.stats(regionChromo, regionStart, regionEnd,  type="mean", nBins=numBin))
 		temp[np.where(temp == None)] = np.nan
 		sampleRC.append(temp.tolist())
@@ -116,8 +115,8 @@ cpdef defineRegion(region):
 
 	#### ctrlMean
 	sampleRC1 = []
-	for rep in range(commonVari.CTRLBW_NUM):
-		bw = pyBigWig.open(commonVari.CTRLBW_NAMES[rep])
+	for rep in range(vari.CTRLBW_NUM):
+		bw = pyBigWig.open(vari.CTRLBW_NAMES[rep])
 		temp = np.array(bw.stats(analysisChromo, regionStart, regionEnd,  type="mean", nBins=binNum))
 		temp[np.where(temp == None)] = np.nan
 		temp = temp.tolist()
@@ -136,8 +135,8 @@ cpdef defineRegion(region):
 
 	#### expMean
 	sampleRC2 = []
-	for rep in range(commonVari.EXPBW_NUM):
-		bw = pyBigWig.open(commonVari.EXPBW_NAMES[rep])
+	for rep in range(vari.EXPBW_NUM):
+		bw = pyBigWig.open(vari.EXPBW_NAMES[rep])
 		temp = np.array(bw.stats(analysisChromo, regionStart, regionEnd,  type="mean", nBins=binNum))
 		temp[np.where(temp == None)] = np.nan
 		temp = temp.tolist()
@@ -231,13 +230,13 @@ cpdef defineRegion(region):
 
 
 	### variance check
-	CTRLBW = [0] * commonVari.CTRLBW_NUM
-	EXPBW = [0] * commonVari.EXPBW_NUM
+	CTRLBW = [0] * vari.CTRLBW_NUM
+	EXPBW = [0] * vari.EXPBW_NUM
 
-	for rep in range(commonVari.CTRLBW_NUM):
-		CTRLBW[rep] = pyBigWig.open(commonVari.CTRLBW_NAMES[rep])
-	for rep in range(commonVari.EXPBW_NUM):
-		EXPBW[rep] = pyBigWig.open(commonVari.EXPBW_NAMES[rep])
+	for rep in range(vari.CTRLBW_NUM):
+		CTRLBW[rep] = pyBigWig.open(vari.CTRLBW_NAMES[rep])
+	for rep in range(vari.EXPBW_NUM):
+		EXPBW[rep] = pyBigWig.open(vari.EXPBW_NAMES[rep])
 
 	if len(definedRegion) == 0:
 		return None
@@ -251,11 +250,11 @@ cpdef defineRegion(region):
 		end = int(definedRegion[regionIdx][2])
 
 		rc = []
-		for rep in range(commonVari.CTRLBW_NUM):
+		for rep in range(vari.CTRLBW_NUM):
 			rcTemp = np.nanmean(CTRLBW[rep].values(chromo, start, end))
 			rc.extend([rcTemp])
 
-		for rep in range(commonVari.EXPBW_NUM):
+		for rep in range(vari.EXPBW_NUM):
 			rcTemp = np.nanmean(EXPBW[rep].values(chromo, start, end))
 			rc.extend([rcTemp])
 
@@ -277,14 +276,14 @@ cpdef defineRegion(region):
 	if len(definedRegion) == 0:
 		return None
 
-	subfile = tempfile.NamedTemporaryFile(mode="w+t", dir=commonVari.OUTPUT_DIR, delete=False)
+	subfile = tempfile.NamedTemporaryFile(mode="w+t", dir=vari.OUTPUT_DIR, delete=False)
 	for line in definedRegion:
 		subfile.write('\t'.join([str(x) for x in line]) + "\n")
 	subfile.close()
 
-	for rep in range(commonVari.CTRLBW_NUM):
+	for rep in range(vari.CTRLBW_NUM):
 		CTRLBW[rep].close()
-	for rep in range(commonVari.EXPBW_NUM):
+	for rep in range(vari.EXPBW_NUM):
 		EXPBW[rep].close()
 
 	return subfile.name
@@ -323,7 +322,7 @@ cpdef doWindowApproach(arg):
 	inputStream = open(inputFilename)
 	inputFile = inputStream.readlines()
 
-	subfile = tempfile.NamedTemporaryFile(mode="w+t", dir=commonVari.OUTPUT_DIR, delete=False)
+	subfile = tempfile.NamedTemporaryFile(mode="w+t", dir=vari.OUTPUT_DIR, delete=False)
 	simesP = []
 	writtenRegionNum = 0
 
@@ -335,14 +334,14 @@ cpdef doWindowApproach(arg):
 		regionTheta = int(temp[4])
 
 		totalRC = []
-		for rep in range(commonVari.CTRLBW_NUM):
-			bw = pyBigWig.open(commonVari.CTRLBW_NAMES[rep])
+		for rep in range(vari.CTRLBW_NUM):
+			bw = pyBigWig.open(vari.CTRLBW_NAMES[rep])
 			temp = bw.values(regionChromo, regionStart, regionEnd)
 			totalRC.append(temp)
 			bw.close()
 
-		for rep in range(commonVari.EXPBW_NUM):
-			bw = pyBigWig.open(commonVari.EXPBW_NAMES[rep])
+		for rep in range(vari.EXPBW_NUM):
+			bw = pyBigWig.open(vari.EXPBW_NAMES[rep])
 			temp = bw.values(regionChromo, regionStart, regionEnd)
 			totalRC.append(temp)
 			bw.close()
@@ -386,7 +385,7 @@ cpdef doWindowApproach(arg):
 				continue
 
 			rc = rc.tolist()
-			if rc == ([0] * commonVari.SAMPLE_NUM):
+			if rc == vari.ALL_ZERO:
 				windowPvalue.extend([np.nan])
 				windowEnrich.extend([np.nan])
 
@@ -449,13 +448,13 @@ cpdef doStatTesting(rc):
 	ctrlRC = []
 	expRC = []
 
-	for rep in range(commonVari.CTRLBW_NUM):
+	for rep in range(vari.CTRLBW_NUM):
 		rc[rep] = float(rc[rep])
 		ctrlRC.extend([rc[rep]])
 
-	for rep in range(commonVari.EXPBW_NUM):
-		rc[rep + commonVari.CTRLBW_NUM] = float(rc[rep+commonVari.CTRLBW_NUM])
-		expRC.extend([rc[rep + commonVari.CTRLBW_NUM] ])
+	for rep in range(vari.EXPBW_NUM):
+		rc[rep + vari.CTRLBW_NUM] = float(rc[rep+vari.CTRLBW_NUM])
+		expRC.extend([rc[rep + vari.CTRLBW_NUM] ])
 
 	ctrlVar = np.nanvar(ctrlRC)
 	expVar = np.nanvar(expRC)
@@ -516,16 +515,16 @@ cpdef doFDRprocedure(args):
 	inputStream = open(inputFilename)
 	inputFile = inputStream.readlines()
 
-	subfile = tempfile.NamedTemporaryFile(mode="w+t", dir=commonVari.OUTPUT_DIR, delete=False)
+	subfile = tempfile.NamedTemporaryFile(mode="w+t", dir=vari.OUTPUT_DIR, delete=False)
 
 	### open bw files to store diff value
-	ctrlBW = [0] * commonVari.CTRLBW_NUM
-	expBW = [0] * commonVari.EXPBW_NUM
+	ctrlBW = [0] * vari.CTRLBW_NUM
+	expBW = [0] * vari.EXPBW_NUM
 
-	for i in range(commonVari.CTRLBW_NUM):
-		ctrlBW[i] = pyBigWig.open(commonVari.CTRLBW_NAMES[i])
-	for i in range(commonVari.EXPBW_NUM):
-		expBW[i] = pyBigWig.open(commonVari.EXPBW_NAMES[i])
+	for i in range(vari.CTRLBW_NUM):
+		ctrlBW[i] = pyBigWig.open(vari.CTRLBW_NAMES[i])
+	for i in range(vari.EXPBW_NUM):
+		expBW[i] = pyBigWig.open(vari.EXPBW_NAMES[i])
 
 	for regionIdx in selectRegionIdx:
 		regionInfo = inputFile[regionIdx].split()
@@ -584,13 +583,13 @@ cpdef doFDRprocedure(args):
 				selectWindowVector[2] = pastEnd
 
 			ctrlRC = []
-			for rep in range(commonVari.CTRLBW_NUM):
+			for rep in range(vari.CTRLBW_NUM):
 				ctrlRC.append(ctrlBW[rep].values(selectWindowVector[0], selectWindowVector[1], selectWindowVector[2]))
 			ctrlRC = np.array(ctrlRC)
 			ctrlRCPosMean = np.mean(ctrlRC, axis=0)
 
 			expRC = []
-			for rep in range(commonVari.EXPBW_NUM):
+			for rep in range(vari.EXPBW_NUM):
 				expRC.append(expBW[rep].values(selectWindowVector[0], selectWindowVector[1], selectWindowVector[2]))
 			expRC = np.array(expRC)
 			expRCPosMean = np.mean(expRC, axis=0)
@@ -626,13 +625,13 @@ cpdef doFDRprocedure(args):
 				selectWindowVector.extend([ np.min(pastQvalueSets) ])
 
 				ctrlRC = []
-				for rep in range(commonVari.CTRLBW_NUM):
+				for rep in range(vari.CTRLBW_NUM):
 					ctrlRC.append(ctrlBW[rep].values(selectWindowVector[0], selectWindowVector[1], selectWindowVector[2]))
 				ctrlRC = np.array(ctrlRC)
 				ctrlRCPosMean = np.mean(ctrlRC, axis=0)
 
 				expRC = []
-				for rep in range(commonVari.EXPBW_NUM):
+				for rep in range(vari.EXPBW_NUM):
 					expRC.append(expBW[rep].values(selectWindowVector[0], selectWindowVector[1], selectWindowVector[2]))
 				expRC = np.array(expRC)
 				expRCPosMean = np.mean(expRC, axis=0)
@@ -668,13 +667,13 @@ cpdef doFDRprocedure(args):
 				selectWindowVector.extend([ np.min(pastQvalueSets) ])
 
 				ctrlRC = []
-				for rep in range(commonVari.CTRLBW_NUM):
+				for rep in range(vari.CTRLBW_NUM):
 					ctrlRC.append(ctrlBW[rep].values(selectWindowVector[0], selectWindowVector[1], selectWindowVector[2]))
 				ctrlRC = np.array(ctrlRC)
 				ctrlRCPosMean = np.mean(ctrlRC, axis=0)
 
 				expRC = []
-				for rep in range(commonVari.EXPBW_NUM):
+				for rep in range(vari.EXPBW_NUM):
 					expRC.append(expBW[rep].values(selectWindowVector[0], selectWindowVector[1], selectWindowVector[2]))
 				expRC = np.array(expRC)
 				expRCPosMean = np.mean(expRC, axis=0)
@@ -696,9 +695,9 @@ cpdef doFDRprocedure(args):
 
 	subfile.close()
 
-	for rep in range(commonVari.CTRLBW_NUM):
+	for rep in range(vari.CTRLBW_NUM):
 		ctrlBW[rep].close()
-	for rep in range(commonVari.EXPBW_NUM):
+	for rep in range(vari.EXPBW_NUM):
 		expBW[rep].close()
 
 	os.remove(inputFilename)

--- a/CRADLE/CallPeak/callPeak.py
+++ b/CRADLE/CallPeak/callPeak.py
@@ -7,17 +7,17 @@ import statsmodels.sandbox.stats.multicomp
 
 from CRADLE.CallPeak import vari
 from CRADLE.CallPeak import calculateRC
-from CRADLE.correctbiasutils import vari as commonVari
+
 
 def mergePeaks(peakResult):
 	## open bigwig files to calculate effect size
-	ctrlBW = [0] * commonVari.CTRLBW_NUM
-	expBW = [0] * commonVari.EXPBW_NUM
+	ctrlBW = [0] * vari.CTRLBW_NUM
+	expBW = [0] * vari.EXPBW_NUM
 
-	for i in range(commonVari.CTRLBW_NUM):
-		ctrlBW[i] = pyBigWig.open(commonVari.CTRLBW_NAMES[i])
-	for i in range(commonVari.EXPBW_NUM):
-		expBW[i] = pyBigWig.open(commonVari.EXPBW_NAMES[i])
+	for i in range(vari.CTRLBW_NUM):
+		ctrlBW[i] = pyBigWig.open(vari.CTRLBW_NAMES[i])
+	for i in range(vari.EXPBW_NUM):
+		expBW[i] = pyBigWig.open(vari.EXPBW_NAMES[i])
 
 	mergedPeak = []
 
@@ -47,13 +47,13 @@ def mergePeaks(peakResult):
 		regionEnd = int(mergedPeak[resultIdx][2])
 
 		ctrlRC = []
-		for rep in range(commonVari.CTRLBW_NUM):
+		for rep in range(vari.CTRLBW_NUM):
 			rc = np.nanmean(np.array(ctrlBW[rep].values(regionChromo, regionStart, regionEnd)))
 			ctrlRC.extend([rc])
 		ctrlRCPosMean = np.nanmean(ctrlRC)
 
 		expRC = []
-		for rep in range(commonVari.EXPBW_NUM):
+		for rep in range(vari.EXPBW_NUM):
 			rc = np.nanmean(np.array(expBW[rep].values(regionChromo, regionStart, regionEnd)))
 			expRC.extend([rc])
 		expRCPosMean = np.nanmean(expRC)
@@ -63,9 +63,9 @@ def mergePeaks(peakResult):
 		mergedPeak[resultIdx][6] = diffPos
 		mergedPeak[resultIdx].extend([ctrlRCPosMean, expRCPosMean, cohens_D])
 
-		for i in range(commonVari.CTRLBW_NUM):
+		for i in range(vari.CTRLBW_NUM):
 			ctrlBW[i].close()
-		for i in range(commonVari.EXPBW_NUM):
+		for i in range(vari.EXPBW_NUM):
 			expBW[i].close()
 
 		return mergedPeak
@@ -103,13 +103,13 @@ def mergePeaks(peakResult):
 			regionEnd = int(mergedPeak[resultIdx][2])
 
 			ctrlRC = []
-			for rep in range(commonVari.CTRLBW_NUM):
+			for rep in range(vari.CTRLBW_NUM):
 				rc = np.nanmean(np.array(ctrlBW[rep].values(regionChromo, regionStart, regionEnd)))
 				ctrlRC.extend([rc])
 			ctrlRCPosMean = np.nanmean(ctrlRC)
 
 			expRC = []
-			for rep in range(commonVari.EXPBW_NUM):
+			for rep in range(vari.EXPBW_NUM):
 				rc = np.nanmean(np.array(expBW[rep].values(regionChromo, regionStart, regionEnd)))
 				expRC.extend([rc])
 			expRCPosMean = np.nanmean(expRC)
@@ -144,13 +144,13 @@ def mergePeaks(peakResult):
 			regionEnd = int(mergedPeak[resultIdx][2])
 
 			ctrlRC = []
-			for rep in range(commonVari.CTRLBW_NUM):
+			for rep in range(vari.CTRLBW_NUM):
 				rc = np.nanmean(np.array(ctrlBW[rep].values(regionChromo, regionStart, regionEnd)))
 				ctrlRC.extend([rc])
 			ctrlRCPosMean = np.nanmean(ctrlRC)
 
 			expRC = []
-			for rep in range(commonVari.EXPBW_NUM):
+			for rep in range(vari.EXPBW_NUM):
 				rc = np.nanmean(np.array(expBW[rep].values(regionChromo, regionStart, regionEnd)))
 				expRC.extend([rc])
 			expRCPosMean = np.nanmean(expRC)
@@ -166,21 +166,21 @@ def mergePeaks(peakResult):
 
 		i = i + 1
 
-	for i in range(commonVari.CTRLBW_NUM):
+	for i in range(vari.CTRLBW_NUM):
 		ctrlBW[i].close()
-	for i in range(commonVari.EXPBW_NUM):
+	for i in range(vari.EXPBW_NUM):
 		expBW[i].close()
 
 	return mergedPeak
 
 
 def calculateCohenD(ctrlRC, expRC):
-	dof = commonVari.CTRLBW_NUM + commonVari.EXPBW_NUM - 2
+	dof = vari.CTRLBW_NUM + vari.EXPBW_NUM - 2
 
 	ctrlRC_mean = np.mean(ctrlRC)
 	expRC_mean = np.mean(expRC)
 
-	s = np.sqrt( (  (commonVari.CTRLBW_NUM-1)*np.power(np.std(ctrlRC, ddof=1), 2) + (commonVari.EXPBW_NUM-1)*np.power(np.std(expRC, ddof=1), 2)  ) / dof )
+	s = np.sqrt( (  (vari.CTRLBW_NUM-1)*np.power(np.std(ctrlRC, ddof=1), 2) + (vari.EXPBW_NUM-1)*np.power(np.std(expRC, ddof=1), 2)  ) / dof )
 
 	cohenD = (expRC_mean - ctrlRC_mean) / s
 
@@ -218,14 +218,13 @@ def filterSmallPeaks(peakResult):
 def run(args):
 	###### INITIALIZE PARAMETERS
 	print("======  INITIALIZING PARAMETERS ...\n")
-	commonVari.setGlobalVariables(args)
 	vari.setGlobalVariables(args)
 
 	##### CALCULATE vari.FILTER_CUTOFF
 	print("======  CALCULATING OVERALL VARIANCE FILTER CUTOFF ...")
 	regionTotal = 0
 	taskVari = []
-	for region in commonVari.REGIONS:
+	for region in vari.REGION:
 		regionSize = int(region[2]) - int(region[1])
 		regionTotal = regionTotal + regionSize
 		taskVari.append(region)
@@ -233,10 +232,10 @@ def run(args):
 		if regionTotal > 3* np.power(10, 8):
 			break
 
-	if len(taskVari) < commonVari.NUMPROCESS:
+	if len(taskVari) < vari.NUMPROCESS:
 		pool = multiprocessing.Pool(len(taskVari))
 	else:
-		pool = multiprocessing.Pool(commonVari.NUMPROCESS)
+		pool = multiprocessing.Pool(vari.NUMPROCESS)
 
 	resultFilter = pool.map_async(calculateRC.getVariance, taskVari).get()
 	pool.close()
@@ -262,7 +261,7 @@ def run(args):
 	# 1)  CALCULATE REGION_CUFOFF
 	regionTotal = 0
 	taskDiff = []
-	for region in commonVari.REGIONS:
+	for region in vari.REGION:
 		regionSize = int(region[2]) - int(region[1])
 		regionTotal = regionTotal + regionSize
 		taskDiff.append(region)
@@ -270,10 +269,10 @@ def run(args):
 		if regionTotal > 3* np.power(10, 8):
 			break
 
-	if len(taskDiff) < commonVari.NUMPROCESS:
+	if len(taskDiff) < vari.NUMPROCESS:
 		pool = multiprocessing.Pool(len(taskDiff))
 	else:
-		pool = multiprocessing.Pool(commonVari.NUMPROCESS)
+		pool = multiprocessing.Pool(vari.NUMPROCESS)
 	resultDiff = pool.map_async(calculateRC.getRegionCutoff, taskDiff).get()
 	pool.close()
 	pool.join()
@@ -292,11 +291,11 @@ def run(args):
 
 
 	# 2)  DEINING REGIONS WITH 'vari.REGION_CUTOFF'
-	if len(commonVari.REGIONS) < commonVari.NUMPROCESS:
-		pool = multiprocessing.Pool(len(commonVari.REGIONS))
+	if len(vari.REGION) < vari.NUMPROCESS:
+		pool = multiprocessing.Pool(len(vari.REGION))
 	else:
-		pool = multiprocessing.Pool(commonVari.NUMPROCESS)
-	resultRegion = pool.map_async(calculateRC.defineRegion, commonVari.REGIONS).get()
+		pool = multiprocessing.Pool(vari.NUMPROCESS)
+	resultRegion = pool.map_async(calculateRC.defineRegion, vari.REGION).get()
 	pool.close()
 	pool.join()
 	gc.collect()
@@ -310,15 +309,15 @@ def run(args):
 			taskWindow.append(resultRegion[i])
 	del resultRegion
 
-	if len(taskWindow) < commonVari.NUMPROCESS:
+	if len(taskWindow) < vari.NUMPROCESS:
 		pool = multiprocessing.Pool(len(taskWindow))
 	else:
-		pool = multiprocessing.Pool(commonVari.NUMPROCESS)
+		pool = multiprocessing.Pool(vari.NUMPROCESS)
 	resultTTest = pool.map_async(calculateRC.doWindowApproach, taskWindow).get()
 	pool.close()
 	pool.join()
 
-	metaFilename = os.path.join(commonVari.OUTPUT_DIR, "metaData_pvalues")
+	metaFilename = vari.OUTPUT_DIR + "/metaData_pvalues"
 	metaStream = open(metaFilename, "w")
 	for i in range(len(resultTTest)):
 		if resultTTest[i] is not None:
@@ -415,13 +414,13 @@ def run(args):
 
 	if len(taskCallPeak) == 0:
 		print("======= COMPLETED! ===========")
-		print("There is no peak detected in %s." % commonVari.OUTPUT_DIR)
+		print("There is no peak detected in %s." % vari.OUTPUT_DIR)
 		return
 
-	if len(taskCallPeak) < commonVari.NUMPROCESS:
+	if len(taskCallPeak) < vari.NUMPROCESS:
 		pool = multiprocessing.Pool(len(taskCallPeak))
 	else:
-		pool = multiprocessing.Pool(commonVari.NUMPROCESS)
+		pool = multiprocessing.Pool(vari.NUMPROCESS)
 	resultCallPeak = pool.map_async(calculateRC.doFDRprocedure, taskCallPeak).get()
 	pool.close()
 	pool.join()
@@ -443,7 +442,7 @@ def run(args):
 
 	if len(peakResult) == 0:
 		print("======= COMPLETED! ===========")
-		print("There is no peak detected in %s." % commonVari.OUTPUT_DIR)
+		print("There is no peak detected in %s." % vari.OUTPUT_DIR)
 		return
 
 
@@ -455,7 +454,7 @@ def run(args):
 	numActi = 0
 	numRepress = 0
 
-	outputFilename = commonVari.OUTPUT_DIR + "/CRADLE_peaks"
+	outputFilename = vari.OUTPUT_DIR + "/CRADLE_peaks"
 	outputStream = open(outputFilename, "w")
 	outputStream.write('\t'.join([str(x) for x in colNames]) + "\n")
 
@@ -495,7 +494,7 @@ def run(args):
 	outputStream.close()
 
 	print("======= COMPLETED! ===========")
-	print("The peak result was saved in %s" % commonVari.OUTPUT_DIR)
+	print("The peak result was saved in %s" % vari.OUTPUT_DIR)
 	print("Total number of peaks: %s" % len(finalResult))
 	print("Activated peaks: %s" % numActi)
 	print("Repressed peaks: %s" % numRepress)

--- a/CRADLE/CallPeak/vari.py
+++ b/CRADLE/CallPeak/vari.py
@@ -1,15 +1,249 @@
+import multiprocessing
+import os
 import sys
+import numpy as np
+import pyBigWig
 
 def setGlobalVariables(args):
-	global DISTANCE
-	global NULL_STD
-	global PEAKLEN
-
+	setInputFiles(args.ctrlbw, args.expbw)
+	setOutputDirectory(args.o)
+	setAnlaysisRegion(args.r, args.bl)
 	setFilterCriteria(args.fdr)
 	setBinSize(args.rbin, args.wbin)
-	PEAKLEN = setPeakLen(args.pl)
-	DISTANCE = args.d
+	setPeakLen(args.pl)
+	setNumProcess(args.p)
+	setDistance(args.d)
 	setStatTesting(args.stat)
+
+def setInputFiles(ctrlbwFiles, expbwFiles):
+	global CTRLBW_NAMES
+	global EXPBW_NAMES
+
+	global CTRLBW_NUM
+	global EXPBW_NUM
+	global SAMPLE_NUM
+
+	global ALL_ZERO
+
+	global NULL_STD
+
+	CTRLBW_NUM = len(ctrlbwFiles)
+	EXPBW_NUM = len(expbwFiles)
+	SAMPLE_NUM = CTRLBW_NUM + EXPBW_NUM
+
+	CTRLBW_NAMES = [0] * CTRLBW_NUM
+	for i in range(CTRLBW_NUM):
+		CTRLBW_NAMES[i] = ctrlbwFiles[i]
+
+	EXPBW_NAMES = [0] * EXPBW_NUM
+	for i in range(EXPBW_NUM):
+		EXPBW_NAMES[i] = expbwFiles[i]
+
+	ALL_ZERO = [0] * SAMPLE_NUM
+
+
+def setOutputDirectory(outputDir):
+	global OUTPUT_DIR
+
+	if outputDir is None:
+		outputDir = os.getcwd() + "/" + "CRADLE_peak_result"
+
+	if outputDir[-1] == "/":
+		outputDir = outputDir[:-1]
+
+	OUTPUT_DIR = outputDir
+
+	dirExist = os.path.isdir(OUTPUT_DIR)
+	if not dirExist:
+		os.makedirs(OUTPUT_DIR)
+
+
+def setAnlaysisRegion(region, bl):
+	global REGION
+
+	REGION = []
+	inputFilename = region
+	inputStream = open(inputFilename)
+	inputFile = inputStream.readlines()
+
+	for i in range(len(inputFile)):
+		temp = inputFile[i].split()
+		temp[1] = int(temp[1])
+		temp[2] = int(temp[2])
+		REGION.append(temp)
+	inputStream.close()
+
+	if len(REGION) > 1:
+		REGION = np.array(REGION)
+		REGION = REGION[np.lexsort(( REGION[:,1].astype(int), REGION[:,0])  ) ]
+		REGION = REGION.tolist()
+
+		regionMerged = []
+
+		pos = 0
+		pastChromo = REGION[pos][0]
+		pastStart = int(REGION[pos][1])
+		pastEnd = int(REGION[pos][2])
+		regionMerged.append([ pastChromo, pastStart, pastEnd])
+		resultIdx = 0
+
+		pos = 1
+		while pos < len(REGION):
+			currChromo = REGION[pos][0]
+			currStart = int(REGION[pos][1])
+			currEnd = int(REGION[pos][2])
+
+			if (currChromo == pastChromo) and (currStart >= pastStart) and (currStart <= pastEnd):
+				maxEnd = np.max([currEnd, pastEnd])
+				regionMerged[resultIdx][2] = maxEnd
+				pos = pos + 1
+				pastChromo = currChromo
+				pastStart = currStart
+				pastEnd = maxEnd
+			else:
+				regionMerged.append([currChromo, currStart, currEnd])
+				resultIdx = resultIdx + 1
+				pos = pos + 1
+				pastChromo = currChromo
+				pastStart = currStart
+				pastEnd = currEnd
+
+		REGION = regionMerged
+
+	if bl is not None:  ### REMOVE BLACKLIST REGIONS FROM 'REGION'
+		blRegionTemp = []
+		inputStream = open(bl)
+		inputFile = inputStream.readlines()
+		for i in range(len(inputFile)):
+			temp = inputFile[i].split()
+			temp[1] = int(temp[1])
+			temp[2] = int(temp[2])
+			blRegionTemp.append(temp)
+
+		## merge overlapping blacklist regions
+		if len(blRegionTemp) == 1:
+			blRegion = blRegionTemp
+			blRegion = np.array(blRegion)
+		else:
+			blRegionTemp = np.array(blRegionTemp)
+			blRegionTemp = blRegionTemp[np.lexsort( ( blRegionTemp[:,1].astype(int), blRegionTemp[:,0] ) )]
+			blRegionTemp = blRegionTemp.tolist()
+
+			blRegion = []
+			pos = 0
+			pastChromo = blRegionTemp[pos][0]
+			pastStart = int(blRegionTemp[pos][1])
+			pastEnd = int(blRegionTemp[pos][2])
+			blRegion.append([pastChromo, pastStart, pastEnd])
+			resultIdx = 0
+
+			pos = 1
+			while pos < len(blRegionTemp):
+				currChromo = blRegionTemp[pos][0]
+				currStart = int(blRegionTemp[pos][1])
+				currEnd = int(blRegionTemp[pos][2])
+
+				if (currChromo == pastChromo) and (currStart >= pastStart) and (currStart <= pastEnd):
+					blRegion[resultIdx][2] = currEnd
+					pos = pos + 1
+					pastChromo = currChromo
+					pastStart = currStart
+					pastEnd = currEnd
+				else:
+					blRegion.append([currChromo, currStart, currEnd])
+					resultIdx = resultIdx + 1
+					pos = pos + 1
+					pastChromo = currChromo
+					pastStart = currStart
+					pastEnd = currEnd
+			blRegion = np.array(blRegion)
+
+		regionWoBL = []
+		for region in REGION:
+			regionChromo = region[0]
+			regionStart = int(region[1])
+			regionEnd = int(region[2])
+
+			overlappedBL = []
+			## overlap Case 1 : A blacklist region completely covers the region.
+			idx = np.where(
+				(blRegion[:,0] == regionChromo) &
+				(blRegion[:,1].astype(int) <= regionStart) &
+				(blRegion[:,2].astype(int) >= regionEnd)
+				)[0]
+			if len(idx) > 0:
+				continue
+
+			## overlap Case 2
+			idx = np.where(
+				(blRegion[:,0] == regionChromo) &
+				(blRegion[:,2].astype(int) > regionStart) &
+				(blRegion[:,2].astype(int) <= regionEnd)
+				)[0]
+			if len(idx) > 0:
+				overlappedBL.extend( blRegion[idx].tolist() )
+
+			## overlap Case 3
+			idx = np.where(
+				(blRegion[:,0] == regionChromo) &
+				(blRegion[:,1].astype(int) >= regionStart) &
+				(blRegion[:,1].astype(int) < regionEnd)
+				)[0]
+
+			if len(idx) > 0:
+				overlappedBL.extend( blRegion[idx].tolist() )
+
+			if len(overlappedBL) == 0:
+				regionWoBL.append(region)
+				continue
+
+			overlappedBL = np.array(overlappedBL)
+			overlappedBL = overlappedBL[overlappedBL[:,1].astype(int).argsort()]
+			overlappedBL = np.unique(overlappedBL, axis=0)
+			overlappedBL = overlappedBL[overlappedBL[:,1].astype(int).argsort()]
+
+			currStart = regionStart
+			for pos in range(len(overlappedBL)):
+				blStart = int(overlappedBL[pos][1])
+				blEnd = int(overlappedBL[pos][2])
+
+				if blStart <= regionStart:
+					currStart = blEnd
+				else:
+					if currStart == blStart:
+						currStart = blEnd
+						continue
+
+					regionWoBL.append([ regionChromo, currStart, blStart ])
+					currStart = blEnd
+
+				if (pos == (len(overlappedBL)-1)) and (blEnd < regionEnd):
+					if blEnd == regionEnd:
+						break
+					regionWoBL.append([ regionChromo, blEnd, regionEnd ])
+
+		REGION = regionWoBL
+
+	# check if all chromosomes in the REGION in bigwig files
+	bw = pyBigWig.open(CTRLBW_NAMES[0])
+	regionFinal = []
+	for regionIdx in range(len(REGION)):
+		chromo = REGION[regionIdx][0]
+		start = int(REGION[regionIdx][1])
+		end = int(REGION[regionIdx][2])
+
+		chromoLen = bw.chroms(chromo)
+		if chromoLen is None:
+			continue
+		if end > chromoLen:
+			REGION[regionIdx][2] = chromoLen
+			if chromoLen <= start:
+				continue
+		regionFinal.append([chromo, start, end])
+	bw.close()
+
+	REGION = regionFinal
+
 
 def setFilterCriteria(fdr):
 	global FDR
@@ -58,11 +292,42 @@ def setBinSize(binSize1, binSize2):
 		SHIFTSIZE2 = BINSIZE2
 
 
-def setPeakLen(peakLen):
-	if peakLen is None:
-		return BINSIZE2
+
+
+def setNumProcess(numProcess):
+	global NUMPROCESS
+
+	systemCPUs = int(multiprocessing.cpu_count())
+
+	if numProcess is None:
+		NUMPROCESS = int(systemCPUs / 2.0 )
+		if NUMPROCESS < 1:
+			NUMPROCESS = 1
 	else:
-		return peakLen
+		NUMPROCESS = int(numProcess)
+
+	if NUMPROCESS > systemCPUs:
+		print("ERROR: You specified too many cpus!")
+		sys.exit()
+
+
+def setDistance(distance):
+	global DISTANCE
+
+	if distance is None:
+		DISTANCE = 10
+	else:
+		DISTANCE = int(distance)
+
+
+def setPeakLen(peakLen):
+	global PEAKLEN
+
+	if peakLen is None:
+		PEAKLEN = int(BINSIZE2)
+	else:
+		PEAKLEN = int(peakLen)
+
 
 def setStatTesting(stat):
 	global EQUALVAR
@@ -78,4 +343,3 @@ def setStatTesting(stat):
 		else:
 			print("ERROR: You should use either 't-test' or 'welch' in -stat")
 			sys.exit()
-


### PR DESCRIPTION
Factoring out common vari methods and changing callPeak to use the
ChromoRegion/ChromoRegionSet classes is more work than its worth
right now (someone needs to use it today).

Reverting callPeak.py and callPeak/vari.py to be independent of the
rest of CRADLE.