### PR TITLE
Rounds CorrectBiasStored results before coalescing sections

### DIFF
--- a/CRADLE/CorrectBiasStored/readCounts.pyx
+++ b/CRADLE/CorrectBiasStored/readCounts.pyx
@@ -109,6 +109,7 @@ cpdef correctReadCounts(regions, covariates, chromoEnds, ctrlBWNames, ctrlScaler
 				rcArr = np.delete(rcArr, idx)
 
 				if len(rcArr) > 0:
+					rcArr = np.rint(rcArr)
 					coalescedSectionCount, startEntries, endEntries, valueEntries = coalesceSections(starts, rcArr, analysisEnd, binsize)
 					writeCorrectedReads(correctedCtrlReadCountFiles[rep], chromoBytes, coalescedSectionCount, startEntries, endEntries, valueEntries)
 				rep += 1
@@ -145,7 +146,9 @@ cpdef correctReadCounts(regions, covariates, chromoEnds, ctrlBWNames, ctrlScaler
 				idx = np.where( (rcArr < np.finfo(np.float32).min) | (rcArr > np.finfo(np.float32).max))
 				starts = np.delete(starts, idx)
 				rcArr = np.delete(rcArr, idx)
+
 				if len(rcArr) > 0:
+					rcArr = np.rint(rcArr)
 					coalescedSectionCount, startEntries, endEntries, valueEntries = coalesceSections(starts, rcArr, analysisEnd, binsize)
 					writeCorrectedReads(correctedExprReadCountFiles[rep], chromoBytes, coalescedSectionCount, startEntries, endEntries, valueEntries)
 				rep += 1

--- a/CRADLE/correctbiasutils/__init__.py
+++ b/CRADLE/correctbiasutils/__init__.py
@@ -422,6 +422,7 @@ def _generateNormalizedObBWs(bwHeader, scaler, regions, observedBW, normObBW):
 
 		values = values[idx]
 		values = values / scaler
+		values = np.rint(values)
 
 		coalescedSectionCount, startEntries, endEntries, valueEntries = coalesceSections(starts, values)
 		normObBW.addEntries([region.chromo] * coalescedSectionCount, startEntries, ends=endEntries, values=valueEntries)

--- a/CRADLE/correctbiasutils/cython.pyx
+++ b/CRADLE/correctbiasutils/cython.pyx
@@ -93,6 +93,9 @@ cpdef writeBedFile(subfile, tempStarts, tempSignalvals, analysisEnd, binsize):
 			break
 
 cpdef coalesceSections(starts, values, analysisEnd=None, stepSize=1):
+	""" Coalesce adjacent sections with the same values into a single sections.
+	Note: This also coerces all the values to integers.
+	"""
 	cdef long [:] startsView
 	cdef long [:] valuesView
 	cdef long cStepSize = stepSize

--- a/tests/correctbiasutils/init_test.py
+++ b/tests/correctbiasutils/init_test.py
@@ -47,7 +47,7 @@ def testFigureFileName(outputDir, bwFilename, result):
 		[('chr17', 12)],
 		2.0,
 		ChromoRegionSet([ChromoRegion('chr17', 1, 5), ChromoRegion('chr17', 8, 12)]),
-		{'chr17': [np.nan, np.nan, np.nan, 0., 0., np.nan, np.nan, np.nan, np.nan, 3., 4., 5.]}
+		{'chr17': [np.nan, np.nan, np.nan, 0., 0., np.nan, np.nan, np.nan, np.nan, 4., 4., 5.]}
 	),
 	(
 		{
@@ -58,7 +58,7 @@ def testFigureFileName(outputDir, bwFilename, result):
 		2.0,
 		ChromoRegionSet([ChromoRegion('chr17', 1, 5), ChromoRegion('chr17', 8, 11), ChromoRegion('chr18', 8, 12)]),
 		{
-			'chr17': [np.nan, np.nan, np.nan, 0., 0., np.nan, np.nan, np.nan, np.nan, 3., 4.],
+			'chr17': [np.nan, np.nan, np.nan, 0., 0., np.nan, np.nan, np.nan, np.nan, 4., 4.],
 			'chr18': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 2., 2.]
 		}
 	),


### PR DESCRIPTION
coalesceSections coerces all values to integers, which truncates them.
This can result in some inaccuracies in the resulting data (e.g.,
3.0 instead 4.0 for a value of 3.7).

This change rounds values to the nearest integer before passing the
data to coalesceSections which will give more accurate output.
