### PR TITLE
Pin statsmodels version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy >= 1.14.3
 argparse >= 1.1
 py2bit >= 0.3.0
 pyBigWig >= 0.3.11
-statsmodels >= 0.8.0
+statsmodels == 0.12.2
 scipy >= 1.0.1
 matplotlib >= 1.5.3
 h5py >= 2.6.0


### PR DESCRIPTION
Statsmodels v0.13.0 throws an exception, so I'm pinning the version to 0.12.2 which is the last known good version.