### PR TITLE
Instantiate link classes

### DIFF
--- a/CRADLE/CorrectBias/regression.pyx
+++ b/CRADLE/CorrectBias/regression.pyx
@@ -69,10 +69,16 @@ cpdef performRegression(covariFiles, scatterplotSamples):
 
 
 		deleteIdx = np.where( (readCounts < np.finfo(np.float32).min) | (readCounts > np.finfo(np.float32).max))[0]
+		loglink = sm.genmod.families.links.log()
+		poisson = sm.families.Poisson(link=loglink)
 		if len(deleteIdx) != 0:
-			model = sm.GLM(np.delete(readCounts.astype(int), deleteIdx), np.delete(np.array(XView), deleteIdx, axis=0), family=sm.families.Poisson(link=sm.genmod.families.links.log)).fit()
+			model = sm.GLM(
+				np.delete(readCounts.astype(int), deleteIdx),
+				np.delete(np.array(XView), deleteIdx, axis=0),
+				family=poisson
+			).fit()
 		else:
-			model = sm.GLM(readCounts.astype(int), np.array(XView), family=sm.families.Poisson(link=sm.genmod.families.links.log)).fit()
+			model = sm.GLM(readCounts.astype(int), np.array(XView), family=poisson).fit()
 
 		coef = model.params
 		COEFCTRL[rep, ] = coef
@@ -96,17 +102,19 @@ cpdef performRegression(covariFiles, scatterplotSamples):
 			os.remove(subfileName)
 
 		deleteIdx = np.where( (readCounts < np.finfo(np.float32).min) | (readCounts > np.finfo(np.float32).max))[0]
+		loglink = sm.genmod.families.links.log()
+		poisson = sm.families.Poisson(link=loglink)
 		if len(deleteIdx) != 0:
 			model = sm.GLM(
 				np.delete(readCounts.astype(int), deleteIdx),
 				np.delete(np.array(XView), deleteIdx, axis=0),
-				family=sm.families.Poisson(link=sm.genmod.families.links.log)
+				family=poisson
 			).fit()
 		else:
 			model = sm.GLM(
 				readCounts.astype(int),
 				np.array(XView),
-				family=sm.families.Poisson(link=sm.genmod.families.links.log)
+				family=poisson
 			).fit()
 
 		coef = model.params

--- a/CRADLE/CorrectBiasStored/regression.py
+++ b/CRADLE/CorrectBiasStored/regression.py
@@ -89,7 +89,9 @@ def getReadCounts(rawReadCounts, rowCount, scaler):
 
 def buildModel(readCounts, xView):
 	#### do regression
-	return sm.GLM(np.array(readCounts).astype(int), np.array(xView), family=sm.families.Poisson(link=sm.genmod.families.links.log)).fit()
+	logLink = sm.genmod.families.links.log()
+	poisson = sm.families.Poisson(link=logLink)
+	return sm.GLM(np.array(readCounts).astype(int), np.array(xView), family=poisson).fit()
 
 def getCoefs(modelParams, selectedCovariates):
 	coef = np.zeros(COEF_LEN, dtype=np.float64)


### PR DESCRIPTION
statsmodel genmod families, as of 0.13.0, require the link to be
an object rather than a class. This change instantiates the log
link classes CRADLE uses to meet the requirement.

This code previously worked, but the functionality of passing a class
had been deprecated for quite some time.
