### PR TITLE
Removes gquadmax argument from correctBias command

### DIFF
--- a/CRADLE/CorrectBias/vari.py
+++ b/CRADLE/CorrectBias/vari.py
@@ -1,7 +1,9 @@
 import math
-import sys
-import numpy as np
 import os
+import sys
+
+import numpy as np
+import pyBigWig
 
 def setGlobalVariables(args):
 	global COEFCTRL
@@ -647,16 +649,15 @@ def setBiasFiles(args):
 		global GQAUDFILE
 		global GQAUD_MAX
 
-		guadFileNum = len(args.gquadFile)
-
-		if guadFileNum == 0:
+		if len(args.gquadFile) == 0:
 			print("ERROR: No g-quadruplex file was specified !")
 			sys.exit()
 
-		GQAUDFILE = [0] * guadFileNum
-		for i in range(guadFileNum):
-			GQAUDFILE[i] = args.gquadFile[i]
-		GQAUD_MAX = args.gquadMax
+		GQAUDFILE = args.gquadFile
+		GQAUD_MAX = -math.inf
+		for gquadFile in GQAUDFILE:
+			with pyBigWig.open(gquadFile) as bw:
+				GQAUD_MAX = max(GQAUD_MAX, bw.header()["maxVal"])
 
 
 def setFilterCriteria(minFrag, sampleNum):

--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ cradle correctBias -ctrlbw ctrl1.bw ctrl2.bw ctrl3.bw
   -  -gquadFile <br />
       Gqaudruplex files in bigwig format. Multiple files are allowed. Required when 'gquad' is in '-biasType'.
       See 'Reference' if you want to download human Gqaudruplex files (hg19 and hg38).
-  -  -gquadMax <br />
-      The maximum gquad score. This is used to normalize Gquad score. default=78.6
   -  -o <br />
       Output directory. All corrected bigwig files will be stored here. If the directory doesn't exist, cradle will make the directory. default=CRADLE_correctionResult.
   -  -p <br />

--- a/bin/cradle
+++ b/bin/cradle
@@ -26,7 +26,6 @@ def getArgs():
 	correctBias_optional.add_argument('-mapFile', help="Mappability file in bigwig format. Required when 'map' is in '-biasType'")
 	correctBias_optional.add_argument('-kmer', help="The length of sequencing reads. If you have paired-end sequencing with 50mer from each end, type '50'. Required when 'map' is in '-biasType'")
 	correctBias_optional.add_argument('-gquadFile', help="Gqaudruplex files in bigwig format. Multiple files are allowed. Required when 'gquad' is in '-biasType'", nargs="+")
-	correctBias_optional.add_argument('-gquadMax', type=float, help="The maximum gquad score. This is used to normalize Gquad score. default=78.6", default=78.6)
 	correctBias_optional.add_argument('-o', help="Output directory. All corrected bigwig files will be stored here. If the directory doesn't exist, cradle will make the directory. default=CRADLE_correctionResult.", required=False, default="CRADLE_correctionResult")
 	correctBias_optional.add_argument('-p', type=int, help="The number of cpus. default=(available cpus)/2")
 	correctBias_optional.add_argument('-bl', help="Text file that shows regions you want to filter out. Each line in the text file should have chromosome, start site, and end site that are tab-spaced. ex) chr1\t1\t100")


### PR DESCRIPTION
Instead of having the user input the gquadmax value, the value is
calculated from the gquad files themselves. Each file has a header
that contains the maxVal in the file, rounded down to the nearest
integer. The largets maxVal across all the gquad files will be used
as the GQUAD_MAX value.
