### PR TITLE
Changes default value for -mi argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## [Unreleased]
+
+### Changed
+
+- Default value for `correctBias` and `correctBias_stored` `-mi` argument is `5 * (number of samples)`. Previously is was just `number of samples`.
+
+## [0.26.1]
+
+### Fixed
+
+- Typo of `ctrlWB` instead of `ctrlBW` in callPeak.py (https://github.com/ReddyLab/CRADLE/issues/91)
+- C-style ternary operator instead of python-style in callPeak.py (https://github.com/ReddyLab/CRADLE/issues/91)
+- Divide by zero error when calculating Cohen's D (https://github.com/ReddyLab/CRADLE/issues/92)

--- a/CRADLE/CorrectBias/vari.py
+++ b/CRADLE/CorrectBias/vari.py
@@ -662,7 +662,7 @@ def setBiasFiles(args):
 
 def setFilterCriteria(minFrag, sampleNum):
 	if minFrag is None:
-		return sampleNum
+		return sampleNum * 5
 	else:
 		return minFrag
 

--- a/CRADLE/CorrectBiasStored/vari.py
+++ b/CRADLE/CorrectBiasStored/vari.py
@@ -118,7 +118,7 @@ def setCovariDir(biasType, covariDir, genome):
 
 def setFilterCriteria(minFrag, sampleNum):
 	if minFrag is None:
-		return sampleNum
+		return sampleNum * 5
 	else:
 		return minFrag
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # CRADLE
 CRADLE (Correcting Read counts and Analysis of DifferentiaLly Expressed regions) is a package that was developed to analyze STARR-seq data. CRADLE removes technical biases from sonication, PCR, mappability and G-quadruplex sturcture, and generates bigwig files with corrected read counts. CRADLE then uses those corrected read counts and detects both activated and repressed enhancers. CRADLE will help find enhancers with better accuracy and credibility.
 
+Please see [CHANGELOG.md] to see what has changed in CRADLE.
+
 ## DISCLAIMER
 CRADLE callPeak subcommand is designed to call peaks using the read counts 'CORRECTED' by either correctBias or correctBias_stored subcommand in CRADLE. CRADLE callPeak subcommand assumes read counts follow a gaussian distribution, so it might not be ideal to use for uncorrected read counts.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ cradle correctBias -ctrlbw ctrl1.bw ctrl2.bw ctrl3.bw
   -  -binSize <br />
       The size of bin (bp) for correction. If you put '1', it means you want to correct read counts in single-bp resolution. (default=1)
   -  -mi <br />
-      The minimum number of fragments. Positions that have less fragments than this value are filtered out. default=the number of samples
+      The minimum number of fragments. Positions that have less fragments than this value are filtered out. default=5 * the number of samples
   -  -mapFile <br />
       Mappability file in bigwig format. Required when 'map' is in '-biasType'. See 'Reference' if you want to download human mappability files (36mer, 50mer, 100mer for hg19 and hg38).
   -  -kmer <br />
@@ -141,7 +141,7 @@ cradle correctBias_stored -ctrlbw ctrl1.bw ctrl2.bw ctrl3.bw
 
 * Optional Arguments
   -  -mi <br />
-     The minimum number of fragments. Positions that have less fragments than this value are filtered out. default=the number of samples
+     The minimum number of fragments. Positions that have less fragments than this value are filtered out. default=5 * the number of samples
   -  -o <br/>
      Output directory. All corrected bigwig files will be stored here. If the directory doesn't exist, cradle will make the directory. default=CRADLE_correctionResult.
   -  -p <br/>


### PR DESCRIPTION
This is the "minimum fragment count" argument. Locations with fewer
fragments will be ignored.