### PR TITLE
Callpeak speedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ CRADLE.egg-info
 test_cradle*
 test_output/**
 
-
+# Ignore profiling
+sciagraph-result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - Major speed improvements (80% reduction) to covariate calculation when pcr is one of the bias types
+- Brought covariate calculation code more in line with idiomatic python, making it easier to maintiain
+- Minor speed improvements to peak calling
+- Brought peak calling code more in line with idiomatic python, making it easier to maintain
 
 ## [0.29.0]
 

--- a/CRADLE/CallPeak/calculateRC.py
+++ b/CRADLE/CallPeak/calculateRC.py
@@ -11,9 +11,9 @@ def getVarianceAndRegionCutoff(region, globalVars):
 	warnings.filterwarnings('ignore', r'Mean of empty slice')
 	warnings.filterwarnings('ignore', r'Degrees of freedom <= 0 for slice')
 
-	regionChromo = region[0]
-	regionStart = region[1]
-	regionEnd = region[2]
+	regionChromo = region["chromo"]
+	regionStart = region["start"]
+	regionEnd = region["end"]
 
 	numBin = max(1, int((regionEnd - regionStart) / globalVars["binSize1"]))
 
@@ -85,9 +85,9 @@ def defineRegion(region, globalVars, ctrlBW, expBW):
 
 	binSize = globalVars["binSize1"]
 
-	analysisChromo = region[0]
-	analysisStart = region[1]
-	analysisEnd = region[2]
+	analysisChromo = region["chromo"]
+	analysisStart = region["start"]
+	analysisEnd = region["end"]
 
 	#### Number of bins
 	binNum = (analysisEnd - analysisStart) // binSize
@@ -169,7 +169,6 @@ def defineRegion(region, globalVars, ctrlBW, expBW):
 			sampleRC2.append(temp)
 
 	expMean = np.nanmean( np.array(sampleRC2), axis=0)
-	del sampleRC2
 
 	#### diff
 	diff = np.array(expMean - ctrlMean, dtype=np.float64)
@@ -180,7 +179,7 @@ def defineRegion(region, globalVars, ctrlBW, expBW):
 	definedRegion = []
 
 	if lastBinExist:
-		binNum = binNum + 1
+		binNum += 1
 
 	while idx < binNum:
 		if np.isnan(diff[idx]):
@@ -189,8 +188,8 @@ def defineRegion(region, globalVars, ctrlBW, expBW):
 				continue
 
 			definedRegion.append(regionVector)
-			numRegion = numRegion + 1
-			idx = idx + 1
+			numRegion += 1
+			idx += 1
 			pastGroupType = -2
 			continue
 

--- a/CRADLE/CallPeak/calculateRC.py
+++ b/CRADLE/CallPeak/calculateRC.py
@@ -337,6 +337,7 @@ def doWindowApproach(regions, globalVars, ctrlBW, expBW):
 			for bwFile in expBW:
 				temp = bwFile.values(regionChromo, regionStart, regionEnd, numpy=True)
 				totalRC.append(temp)
+			totalRC = np.stack(totalRC)
 		else:
 			for bwFile in ctrlBW:
 				temp = bwFile.values(regionChromo, regionStart, regionEnd)
@@ -345,8 +346,8 @@ def doWindowApproach(regions, globalVars, ctrlBW, expBW):
 			for bwFile in expBW:
 				temp = bwFile.values(regionChromo, regionStart, regionEnd)
 				totalRC.append(temp)
+			totalRC = np.array(totalRC)
 
-		totalRC = np.array(totalRC)
 		binStartIdx = 0
 		analysisEndIdx = regionEnd - regionStart
 

--- a/CRADLE/CallPeak/calculateRC.py
+++ b/CRADLE/CallPeak/calculateRC.py
@@ -380,10 +380,9 @@ def doWindowApproach(regions, globalVars, ctrlBW, expBW):
 				numWindow = len(windowPvalueWoNan)
 				pMerged = np.min((windowPvalueWoNan * numWindow) / rankPvalue)
 
-				regionInfo = f"{regionChromo}\t{strRegionStart}\t{strRegionEnd}\t{strRegionTheta}\t{pMerged}\t"
-				subfile.write(regionInfo)
-				subfile.write(','.join([str(x) for x in windowPvalue]) + "\t")
-				subfile.write(','.join(windowEnrich) + "\n")
+				subfile.write(f"{regionChromo}\t{strRegionStart}\t{strRegionEnd}\t{strRegionTheta}\t{pMerged}\t")
+				subfile.write(f"{','.join([str(x) for x in windowPvalue])}\t")
+				subfile.write(f"{','.join(windowEnrich)}\n")
 				writtenRegion = True
 
 			binStartIdx += shiftSize2

--- a/CRADLE/CallPeak/calculateRC.py
+++ b/CRADLE/CallPeak/calculateRC.py
@@ -458,10 +458,13 @@ def selectTheta(resultTTestFiles, globalVars):
 	totalRegionNumArray = []
 	selectRegionNumArray = []
 
+	values = {}
+
 	for theta in globalVars["filterCutoffsThetas"]:
 		pValueSimes = []
 
 		for ttestFile in resultTTestFiles:
+			values[ttestFile] = []
 			with open(ttestFile) as ttestResults:
 				for region in ttestResults:
 					regionLine = region.split()
@@ -471,12 +474,14 @@ def selectTheta(resultTTestFiles, globalVars):
 					if np.isnan(regionPvalue):
 						continue
 
+					values[ttestFile].append((regionTheta, regionPvalue))
+
 					if regionTheta >= theta:
 						pValueSimes.append(regionPvalue)
 
 		totalRegionNum = len(pValueSimes)
-		pValueGroupBh = statsmodels.sandbox.stats.multicomp.multipletests(pValueSimes, alpha=alpha, method='fdr_bh')
-		selectRegionNum = len(np.where(pValueGroupBh[0])[0])
+		pValueGroupBh = statsmodels.sandbox.stats.multicomp.multipletests(pValueSimes, alpha=alpha, method='fdr_bh')[0]
+		selectRegionNum = len(np.where(pValueGroupBh)[0])
 
 		totalRegionNumArray.append(totalRegionNum)
 		selectRegionNumArray.append(selectRegionNum)
@@ -488,7 +493,7 @@ def selectTheta(resultTTestFiles, globalVars):
 
 	adjFDR = ( globalVars["fdr"] * selectRegionNumArray[idx] ) / totalRegionNumArray[idx]
 
-	return globalVars["filterCutoffsThetas"][idx], adjFDR, selectRegionNumArray[idx], totalRegionNumArray[idx]
+	return globalVars["filterCutoffsThetas"][idx], adjFDR, selectRegionNumArray[idx], totalRegionNumArray[idx], values
 
 
 def doFDRprocedure(inputFilename, selectRegionIdx, globalVars):

--- a/CRADLE/CallPeak/calculateRC.pyx
+++ b/CRADLE/CallPeak/calculateRC.pyx
@@ -813,50 +813,6 @@ cpdef truncateNan(peakStart, peakEnd, diffPos):
 			return [peakStart], [peakEnd], [peakDiff]
 
 
-cpdef selectTheta(metaDataName, globalVars):
-	inputFilename = metaDataName
-	inputStream = open(inputFilename)
-	inputFile = inputStream.readlines()
-
-	totalRegionNumArray = []
-	selectRegionNumArray = []
-
-	for thetaIdx in range(len(globalVars["filterCutoffsThetas"])):
-		theta = int(globalVars["filterCutoffsThetas"][thetaIdx])
-
-		PValueSimes = []
-
-		for subFileIdx in range(len(inputFile)):
-			subfileName = inputFile[subFileIdx].split()[0]
-			subfileStream = open(subfileName)
-			subfileContents = subfileStream.readlines()
-
-			for regionIdx in range(len(subfileContents)):
-				line = subfileContents[regionIdx].split()
-				regionTheta = int(line[3])
-				regionPvalue = float(line[4])
-
-				if np.isnan(regionPvalue):
-					continue
-
-				if regionTheta >= theta:
-					PValueSimes.extend([ regionPvalue ])
-
-		totalRegionNum =  len(PValueSimes)
-		PValueGroupBh = statsmodels.sandbox.stats.multicomp.multipletests(PValueSimes, alpha=globalVars["fdr"], method='fdr_bh')
-		selectRegionNum = len(np.where(PValueGroupBh[0])[0])
-
-		totalRegionNumArray.extend([totalRegionNum])
-		selectRegionNumArray.extend([selectRegionNum])
-
-	selectRegionNumArray = np.array(selectRegionNumArray)
-	maxNum = np.max(selectRegionNumArray)
-	idx = np.where(selectRegionNumArray == maxNum)
-	idx = idx[0][0]
-
-	return [globalVars["filterCutoffsThetas"][idx], selectRegionNumArray[idx], totalRegionNumArray[idx]]
-
-
 cpdef writePeak(selectWindowVector, subPeakStarts, subPeakEnds, subPeakDiffs, subfile):
 	for subPeakNum in range(len(subPeakStarts)):
 		testResult = testSubPeak(subPeakDiffs[subPeakNum], selectWindowVector[3])

--- a/CRADLE/CallPeak/callPeak.py
+++ b/CRADLE/CallPeak/callPeak.py
@@ -206,9 +206,13 @@ def filterSmallPeaks(peakResult, globalVars):
 
 
 def run(args):
+	globalVars = vari.setGlobalVariables(args)
+	with multiprocessing.Pool(globalVars["numprocess"]) as pool:
+		_run(globalVars, pool)
+
+def _run(globalVars, pool):
 	###### INITIALIZE PARAMETERS
 	print("======  INITIALIZING PARAMETERS ...\n")
-	globalVars = vari.setGlobalVariables(args)
 
 	##### CALCULATE FILTER_CUTOFF
 	print("======  CALCULATING OVERALL VARIANCE FILTER CUTOFF ...")
@@ -222,8 +226,7 @@ def run(args):
 		if regionTotal > 300_000_000:
 			break
 
-	with multiprocessing.Pool(min(len(taskVari), globalVars["numprocess"])) as pool:
-		variancesAndCutoffs = pool.starmap(calculateRC.getVarianceAndRegionCutoff, taskVari)
+	variancesAndCutoffs = pool.starmap(calculateRC.getVarianceAndRegionCutoff, taskVari)
 
 	variances = []
 	diff = []
@@ -250,8 +253,7 @@ def run(args):
 	print("======  PERFORMING STATSTICAL TESTING FOR EACH REGION ...")
 	tasks = [(region, globalVars) for region in globalVars["region"]]
 
-	with multiprocessing.Pool(min(len(tasks), globalVars["numprocess"])) as pool:
-		resultTTestFiles = pool.starmap(calculateRC.statTest, tasks)
+	resultTTestFiles = pool.starmap(calculateRC.statTest, tasks)
 
 	resultTTestFiles = [file for file in resultTTestFiles if file is not None]
 
@@ -313,8 +315,7 @@ def run(args):
 		print(f"There is no peak detected in {globalVars['outputDir']}.")
 		return
 
-	with multiprocessing.Pool(min(len(taskCallPeak), globalVars["numprocess"])) as pool:
-		resultCallPeak = pool.starmap(calculateRC.doFDRprocedure, taskCallPeak)
+	resultCallPeak = pool.starmap(calculateRC.doFDRprocedure, taskCallPeak)
 
 	peakResult = []
 	for inputFilename in resultCallPeak:

--- a/CRADLE/CallPeak/callPeak.py
+++ b/CRADLE/CallPeak/callPeak.py
@@ -121,7 +121,7 @@ def mergePeaks(peakResult, globalVars):
 		pastEnd = currEnd
 		pastEnrich = currEnrich
 
-		i = i + 1
+		i += 1
 
 	for i in range(globalVars["ctrlbwNum"]):
 		ctrlBW[i].close()
@@ -238,9 +238,6 @@ def run(args):
 	globalVars["filterCutoffs"] = np.array(globalVars["filterCutoffs"])
 
 	print(f"Variance Cutoff: {np.round(globalVars['filterCutoffs'])}")
-	del pool, var, resultFilter
-	gc.collect()
-
 
 	##### DEFINING REGIONS
 	print("======  DEFINING REGIONS ...")
@@ -269,9 +266,6 @@ def run(args):
 	print(f"Null_std: {globalVars['nullStd']}")
 	globalVars["regionCutoff"] = np.percentile(np.array(diff), 99)
 	print(f"Region cutoff: {globalVars['regionCutoff']}")
-	del pool, resultDiff, diff, taskDiff
-	gc.collect()
-
 
 	# 2)  DEINING REGIONS WITH 'globalVars["regionCutoff"]'
 	pool = multiprocessing.Pool(min(len(globalVars["region"]), globalVars["numprocess"]))
@@ -279,7 +273,6 @@ def run(args):
 	resultRegion = pool.starmap_async(calculateRC.defineRegion, tasks).get()
 	pool.close()
 	pool.join()
-	gc.collect()
 
 
 	##### STATISTICAL TESTING FOR EACH region
@@ -288,7 +281,6 @@ def run(args):
 	for rRegion in resultRegion:
 		if rRegion is not None:
 			taskWindow.append((rRegion, globalVars))
-	del resultRegion
 
 	pool = multiprocessing.Pool(min(len(taskWindow), globalVars["numprocess"]))
 	resultTTest = pool.starmap_async(calculateRC.doWindowApproach, taskWindow).get()
@@ -301,7 +293,6 @@ def run(args):
 		if rTTest is not None:
 			metaStream.write(rTTest + "\n")
 	metaStream.close()
-	del taskWindow, pool, resultTTest
 
 	##### CHOOSING THETA
 	resultTheta = calculateRC.selectTheta(metaFilename, globalVars)
@@ -395,9 +386,6 @@ def run(args):
 	resultCallPeak = pool.starmap_async(calculateRC.doFDRprocedure, taskCallPeak).get()
 	pool.close()
 	pool.join()
-
-	del pool, taskCallPeak
-	gc.collect()
 
 	peakResult = []
 	for inputFilename in resultCallPeak:

--- a/CRADLE/CallPeak/callPeak.py
+++ b/CRADLE/CallPeak/callPeak.py
@@ -138,44 +138,6 @@ def mergePeaks(peakResult, globalVars):
 	return mergedPeak
 
 
-def selectTheta(resultTTestFiles, globalVars):
-	alpha = globalVars["fdr"]
-
-	totalRegionNumArray = []
-	selectRegionNumArray = []
-
-	for theta in globalVars["filterCutoffsThetas"]:
-		pValueSimes = []
-
-		for ttestFile in resultTTestFiles:
-			with open(ttestFile) as ttestResults:
-				for region in ttestResults:
-					regionLine = region.split()
-					regionTheta = int(regionLine[3])
-					regionPvalue = float(regionLine[4])
-
-					if np.isnan(regionPvalue):
-						continue
-
-					if regionTheta >= theta:
-						pValueSimes.append(regionPvalue)
-
-		totalRegionNum = len(pValueSimes)
-		pValueGroupBh = statsmodels.sandbox.stats.multicomp.multipletests(pValueSimes, alpha=alpha, method='fdr_bh')
-		selectRegionNum = len(np.where(pValueGroupBh[0])[0])
-
-		totalRegionNumArray.append(totalRegionNum)
-		selectRegionNumArray.append(selectRegionNum)
-
-	selectRegionNumArray = np.array(selectRegionNumArray)
-	maxNum = np.max(selectRegionNumArray)
-	idx = np.where(selectRegionNumArray == maxNum)
-	idx = idx[0][0]
-
-	adjFDR = ( globalVars["fdr"] * selectRegionNumArray[idx] ) / totalRegionNumArray[idx]
-
-	return globalVars["filterCutoffsThetas"][idx], adjFDR, selectRegionNumArray[idx], totalRegionNumArray[idx]
-
 def takeMinusLog(values):
 	minValue = np.min(values)
 
@@ -294,7 +256,7 @@ def run(args):
 	resultTTestFiles = [file for file in resultTTestFiles if file is not None]
 
 	##### CHOOSING THETA
-	resultTheta = selectTheta(resultTTestFiles, globalVars)
+	resultTheta = calculateRC.selectTheta(resultTTestFiles, globalVars)
 
 	globalVars["theta"] = resultTheta[0]
 	globalVars["adjFDR"] = resultTheta[1]

--- a/CRADLE/CallPeak/callPeak.py
+++ b/CRADLE/CallPeak/callPeak.py
@@ -260,8 +260,8 @@ def run(args):
 	regionTotal = 0
 	taskVari = []
 	for region in globalVars["region"]:
-		regionSize = int(region[2]) - int(region[1])
-		regionTotal = regionTotal + regionSize
+		regionSize = region[2] - region[1]
+		regionTotal += regionSize
 		taskVari.append((region, globalVars))
 
 		if regionTotal > 300_000_000:
@@ -284,19 +284,9 @@ def run(args):
 
 	##### DEFINING REGIONS
 	print("======  DEFINING REGIONS ...")
-	# 1)  CALCULATE region_CUFOFF
-	regionTotal = 0
-	taskDiff = []
-	for region in globalVars["region"]:
-		regionSize = int(region[2]) - int(region[1])
-		regionTotal = regionTotal + regionSize
-		taskDiff.append((region, globalVars))
-
-		if regionTotal > 300_000_000:
-			break
-
-	with multiprocessing.Pool(min(len(taskDiff), globalVars["numprocess"])) as pool:
-		resultDiff = pool.starmap(calculateRC.getRegionCutoff, taskDiff)
+	# 1)  CALCULATE REGION_CUTOFF
+	with multiprocessing.Pool(min(len(taskVari), globalVars["numprocess"])) as pool:
+		resultDiff = pool.starmap(calculateRC.getRegionCutoff, taskVari)
 
 	diff = []
 	for rDiff in resultDiff:
@@ -315,10 +305,7 @@ def run(args):
 
 
 	print("======  PERFORMING STATSTICAL TESTING FOR EACH REGION ...")
-	taskWindow = []
-	for rRegion in resultRegion:
-		if rRegion is not None:
-			taskWindow.append((rRegion, globalVars))
+	taskWindow = [(rRegion, globalVars) for rRegion in resultRegion if rRegion is not None]
 
 	with multiprocessing.Pool(min(len(taskWindow), globalVars["numprocess"])) as pool:
 		resultTTest = pool.starmap(calculateRC.doWindowApproach, taskWindow)

--- a/CRADLE/CallPeak/callPeak.py
+++ b/CRADLE/CallPeak/callPeak.py
@@ -219,7 +219,7 @@ def _run(globalVars, pool):
 	regionTotal = 0
 	taskVari = []
 	for region in globalVars["region"]:
-		regionSize = region[2] - region[1]
+		regionSize = region["end"] - region["start"]
 		regionTotal += regionSize
 		taskVari.append((region, globalVars))
 

--- a/CRADLE/CallPeak/vari.py
+++ b/CRADLE/CallPeak/vari.py
@@ -83,7 +83,9 @@ def setNormalizedInputFiles(normCtrlbw, normExpbw):
 	global NORM_EXPBW_NAMES
 
 	if  len(normCtrlbw) != CTRLBW_NUM or len(normExpbw) != EXPBW_NUM:
-		print("Error: The number of normalized observed bigwigs does not match with the number of input bigwigs. The number of bigwigs in -ctrlbw and -expbw should match with the nubmer of biwigs in -normCtrlbw and -normExpbw, respectively.")
+		print("""Error: The number of normalized observed bigwigs does not match with the
+	number of input bigwigs. The number of bigwigs in -ctrlbw and -expbw should match
+	with the nubmer of biwigs in -normCtrlbw and -normExpbw, respectively.""")
 		sys.exit()
 
 	NORM_CTRLBW_NAMES = normCtrlbw
@@ -94,7 +96,7 @@ def setOutputDirectory(outputDir):
 	global OUTPUT_DIR
 
 	if outputDir is None:
-		outputDir = os.getcwd() + "/" + "CRADLE_peak_result"
+		outputDir = os.getcwd() + "/CRADLE_peak_result"
 
 	if outputDir[-1] == "/":
 		outputDir = outputDir[:-1]
@@ -112,10 +114,10 @@ def setAnlaysisRegion(region, bl):
 	REGION = []
 	inputFilename = region
 	inputStream = open(inputFilename)
-	inputFile = inputStream.readlines()
+	inputFiles = inputStream.readlines()
 
-	for i in range(len(inputFile)):
-		temp = inputFile[i].split()
+	for inputFile in inputFiles:
+		temp = inputFile.split()
 		temp[1] = int(temp[1])
 		temp[2] = int(temp[2])
 		REGION.append(temp)
@@ -161,9 +163,9 @@ def setAnlaysisRegion(region, bl):
 	if bl is not None:  ### REMOVE BLACKLIST REGIONS FROM 'REGION'
 		blRegionTemp = []
 		inputStream = open(bl)
-		inputFile = inputStream.readlines()
-		for i in range(len(inputFile)):
-			temp = inputFile[i].split()
+		inputFiles = inputStream.readlines()
+		for inputFile in inputFiles:
+			temp = inputFile.split()
 			temp[1] = int(temp[1])
 			temp[2] = int(temp[2])
 			blRegionTemp.append(temp)
@@ -251,9 +253,9 @@ def setAnlaysisRegion(region, bl):
 			overlappedBL = overlappedBL[overlappedBL[:,1].astype(int).argsort()]
 
 			currStart = regionStart
-			for pos in range(len(overlappedBL)):
-				blStart = int(overlappedBL[pos][1])
-				blEnd = int(overlappedBL[pos][2])
+			for pos in overlappedBL:
+				blStart = int(pos[1])
+				blEnd = int(pos[2])
 
 				if blStart <= regionStart:
 					currStart = blEnd
@@ -273,22 +275,22 @@ def setAnlaysisRegion(region, bl):
 		REGION = regionWoBL
 
 	# check if all chromosomes in the REGION in bigwig files
-	bw = pyBigWig.open(CTRLBW_NAMES[0])
+	bigWig = pyBigWig.open(CTRLBW_NAMES[0])
 	regionFinal = []
-	for regionIdx in range(len(REGION)):
-		chromo = REGION[regionIdx][0]
-		start = int(REGION[regionIdx][1])
-		end = int(REGION[regionIdx][2])
+	for regionTuple in REGION:
+		chromo = regionTuple[0]
+		start = int(regionTuple[1])
+		end = int(regionTuple[2])
 
-		chromoLen = bw.chroms(chromo)
+		chromoLen = bigWig.chroms(chromo)
 		if chromoLen is None:
 			continue
 		if end > chromoLen:
-			REGION[regionIdx][2] = chromoLen
+			regionTuple[2] = chromoLen
 			if chromoLen <= start:
 				continue
 		regionFinal.append([chromo, start, end])
-	bw.close()
+	bigWig.close()
 
 	REGION = regionFinal
 
@@ -328,7 +330,7 @@ def setBinSize(binSize1, binSize2):
 	elif (binSize1 is None)  and (binSize2 is not None):
 		BINSIZE1 = 300
 		if int(binSize2) > BINSIZE1:
-			print("Error: wbin cannot be larger than rbin (%sbp)" % BINSIZE1)
+			print(f"Error: wbin cannot be larger than rbin ({BINSIZE1}bp)")
 			sys.exit()
 		else:
 			BINSIZE2 = int(binSize2)

--- a/CRADLE/CallPeak/vari.py
+++ b/CRADLE/CallPeak/vari.py
@@ -252,7 +252,7 @@ def setAnlaysisRegion(regionsFile, blacklistFile):
 		regionFinal.append((chromo, start, min(end, chromoLen)))
 	bigWig.close()
 
-	REGION = regionFinal
+	REGION = np.array(regionFinal, dtype=REGION_DTYPE)
 
 
 def setFilterCriteria(fdr):

--- a/CRADLE/CallPeak/vari.py
+++ b/CRADLE/CallPeak/vari.py
@@ -73,14 +73,16 @@ def setInputFiles(ctrlbwFiles, expbwFiles):
 
 def setNormalizedInputFiles(normCtrlbw, normExpbw):
 	global I_LOG2FC
+	global NORM_CTRLBW_NAMES
+	global NORM_EXPBW_NAMES
 
 	if normCtrlbw is None or normExpbw is None:
 		I_LOG2FC = False
+		NORM_CTRLBW_NAMES = None
+		NORM_EXPBW_NAMES = None
 		return
 
 	I_LOG2FC = True
-	global NORM_CTRLBW_NAMES
-	global NORM_EXPBW_NAMES
 
 	if  len(normCtrlbw) != CTRLBW_NUM or len(normExpbw) != EXPBW_NUM:
 		print("""Error: The number of normalized observed bigwigs does not match with the

--- a/CRADLE/CallPeak/vari.py
+++ b/CRADLE/CallPeak/vari.py
@@ -4,6 +4,8 @@ import sys
 import numpy as np
 import pyBigWig
 
+REGION_DTYPE = np.dtype([("chromo", "U7"), ("start", "i4"), ("end", "i4")])
+
 def setGlobalVariables(args):
 	setInputFiles(args.ctrlbw, args.expbw)
 	setNormalizedInputFiles(args.normCtrlbw, args.normExpbw)
@@ -98,7 +100,7 @@ def setOutputDirectory(outputDir):
 	global OUTPUT_DIR
 
 	if outputDir is None:
-		outputDir = os.getcwd() + "/CRADLE_peak_result"
+		outputDir = os.path.join(os.getcwd(), "CRADLE_peak_result")
 
 	if outputDir[-1] == "/":
 		outputDir = outputDir[:-1]
@@ -110,154 +112,116 @@ def setOutputDirectory(outputDir):
 		os.makedirs(OUTPUT_DIR)
 
 
-def setAnlaysisRegion(region, bl):
+def setAnlaysisRegion(regionsFile, blacklistFile):
 	global REGION
 
 	REGION = []
-	inputFilename = region
-	inputStream = open(inputFilename)
-	inputFiles = inputStream.readlines()
-
-	for inputFile in inputFiles:
-		temp = inputFile.split()
-		temp[1] = int(temp[1])
-		temp[2] = int(temp[2])
-		REGION.append(temp)
-	inputStream.close()
+	with open(regionsFile) as regions:
+		for region in regions:
+			temp = region.split()
+			REGION.append((temp[0], int(temp[1]), int(temp[2])))
 
 	if len(REGION) > 1:
-		REGION = np.array(REGION)
-		REGION = REGION[np.lexsort(( REGION[:,1].astype(int), REGION[:,0])  ) ]
-		REGION = REGION.tolist()
+		REGION = np.array(REGION, dtype=REGION_DTYPE)
+		REGION = REGION[np.lexsort((REGION[:]["start"], REGION[:]["chromo"]))]
 
 		regionMerged = []
 
-		pos = 0
-		pastChromo = REGION[pos][0]
-		pastStart = int(REGION[pos][1])
-		pastEnd = int(REGION[pos][2])
+		pastChromo, pastStart, pastEnd = REGION[0]
 		regionMerged.append([ pastChromo, pastStart, pastEnd])
 		resultIdx = 0
 
-		pos = 1
-		while pos < len(REGION):
-			currChromo = REGION[pos][0]
-			currStart = int(REGION[pos][1])
-			currEnd = int(REGION[pos][2])
-
-			if (currChromo == pastChromo) and (currStart >= pastStart) and (currStart <= pastEnd):
+		for currChromo, currStart, currEnd in REGION[1:]:
+			if (currChromo == pastChromo) and (pastStart <= currStart <= pastEnd):
 				maxEnd = np.max([currEnd, pastEnd])
 				regionMerged[resultIdx][2] = maxEnd
-				pos = pos + 1
-				pastChromo = currChromo
-				pastStart = currStart
 				pastEnd = maxEnd
 			else:
 				regionMerged.append([currChromo, currStart, currEnd])
-				resultIdx = resultIdx + 1
-				pos = pos + 1
-				pastChromo = currChromo
-				pastStart = currStart
+				resultIdx += 1
 				pastEnd = currEnd
+
+			pastChromo = currChromo
+			pastStart = currStart
 
 		REGION = regionMerged
 
-	if bl is not None:  ### REMOVE BLACKLIST REGIONS FROM 'REGION'
+	if blacklistFile is not None:  ### REMOVE BLACKLIST REGIONS FROM 'REGION'
 		blRegionTemp = []
-		inputStream = open(bl)
-		inputFiles = inputStream.readlines()
-		for inputFile in inputFiles:
-			temp = inputFile.split()
-			temp[1] = int(temp[1])
-			temp[2] = int(temp[2])
-			blRegionTemp.append(temp)
+		with open(blacklistFile) as blacklistRegions:
+			for blacklistRegion in blacklistRegions:
+				temp = blacklistRegion.split()
+				blRegionTemp.append((temp[0], int(temp[1]), int(temp[2])))
 
 		## merge overlapping blacklist regions
 		if len(blRegionTemp) == 1:
 			blRegion = blRegionTemp
-			blRegion = np.array(blRegion)
 		else:
-			blRegionTemp = np.array(blRegionTemp)
-			blRegionTemp = blRegionTemp[np.lexsort( ( blRegionTemp[:,1].astype(int), blRegionTemp[:,0] ) )]
-			blRegionTemp = blRegionTemp.tolist()
+			blRegionTemp = np.array(blRegionTemp, dtype=REGION_DTYPE)
+			blRegionTemp = blRegionTemp[np.lexsort((blRegionTemp[:]["start"], blRegionTemp[:]["chromo"]))]
 
 			blRegion = []
-			pos = 0
-			pastChromo = blRegionTemp[pos][0]
-			pastStart = int(blRegionTemp[pos][1])
-			pastEnd = int(blRegionTemp[pos][2])
-			blRegion.append([pastChromo, pastStart, pastEnd])
+			pastChromo, pastStart, pastEnd = blRegionTemp[0]
+
+			blRegion.append((pastChromo, pastStart, pastEnd))
 			resultIdx = 0
 
-			pos = 1
-			while pos < len(blRegionTemp):
-				currChromo = blRegionTemp[pos][0]
-				currStart = int(blRegionTemp[pos][1])
-				currEnd = int(blRegionTemp[pos][2])
-
-				if (currChromo == pastChromo) and (currStart >= pastStart) and (currStart <= pastEnd):
-					blRegion[resultIdx][2] = currEnd
-					pos = pos + 1
-					pastChromo = currChromo
-					pastStart = currStart
-					pastEnd = currEnd
+			for currChromo, currStart, currEnd in blRegionTemp[1:]:
+				if (currChromo == pastChromo) and (pastStart <= currStart <= pastEnd):
+					blRegion[resultIdx] = (blRegion[resultIdx][0], blRegion[resultIdx][1], currEnd)
 				else:
-					blRegion.append([currChromo, currStart, currEnd])
-					resultIdx = resultIdx + 1
-					pos = pos + 1
-					pastChromo = currChromo
-					pastStart = currStart
-					pastEnd = currEnd
-			blRegion = np.array(blRegion)
+					blRegion.append((currChromo, currStart, currEnd))
+					resultIdx += 1
+
+				pastChromo = currChromo
+				pastStart = currStart
+				pastEnd = currEnd
+		blRegion = np.array(blRegion, dtype=REGION_DTYPE)
 
 		regionWoBL = []
-		for region in REGION:
-			regionChromo = region[0]
-			regionStart = int(region[1])
-			regionEnd = int(region[2])
-
+		for regionChromo, regionStart, regionEnd in REGION:
 			overlappedBL = []
 			## overlap Case 1 : A blacklist region completely covers the region.
 			idx = np.where(
-				(blRegion[:,0] == regionChromo) &
-				(blRegion[:,1].astype(int) <= regionStart) &
-				(blRegion[:,2].astype(int) >= regionEnd)
+				(blRegion[:]["chromo"] == regionChromo) &
+				(blRegion[:]["start"] <= regionStart) &
+				(blRegion[:]["end"] >= regionEnd)
 				)[0]
 			if len(idx) > 0:
 				continue
 
 			## overlap Case 2
 			idx = np.where(
-				(blRegion[:,0] == regionChromo) &
-				(blRegion[:,2].astype(int) > regionStart) &
-				(blRegion[:,2].astype(int) <= regionEnd)
+				(blRegion[:]["chromo"] == regionChromo) &
+				(blRegion[:]["end"] > regionStart) &
+				(blRegion[:]["end"] <= regionEnd)
 				)[0]
 			if len(idx) > 0:
 				overlappedBL.extend( blRegion[idx].tolist() )
 
 			## overlap Case 3
 			idx = np.where(
-				(blRegion[:,0] == regionChromo) &
-				(blRegion[:,1].astype(int) >= regionStart) &
-				(blRegion[:,1].astype(int) < regionEnd)
+				(blRegion[:]["chromo"] == regionChromo) &
+				(blRegion[:]["start"] >= regionStart) &
+				(blRegion[:]["start"] < regionEnd)
 				)[0]
 
 			if len(idx) > 0:
 				overlappedBL.extend( blRegion[idx].tolist() )
 
 			if len(overlappedBL) == 0:
-				regionWoBL.append(region)
+				regionWoBL.append((regionChromo, regionStart, regionEnd))
 				continue
 
-			overlappedBL = np.array(overlappedBL)
-			overlappedBL = overlappedBL[overlappedBL[:,1].astype(int).argsort()]
+			overlappedBL = np.array(overlappedBL, dtype=REGION_DTYPE)
+			overlappedBL = overlappedBL[overlappedBL[:]["start"].argsort()]
 			overlappedBL = np.unique(overlappedBL, axis=0)
-			overlappedBL = overlappedBL[overlappedBL[:,1].astype(int).argsort()]
+			overlappedBL = overlappedBL[overlappedBL[:]["start"].argsort()]
 
 			currStart = regionStart
 			for pos in overlappedBL:
-				blStart = int(pos[1])
-				blEnd = int(pos[2])
+				blStart = pos["start"]
+				blEnd = pos["end"]
 
 				if blStart <= regionStart:
 					currStart = blEnd
@@ -266,32 +230,26 @@ def setAnlaysisRegion(region, bl):
 						currStart = blEnd
 						continue
 
-					regionWoBL.append([ regionChromo, currStart, blStart ])
+					regionWoBL.append((regionChromo, currStart, blStart))
 					currStart = blEnd
 
-				if (pos == (len(overlappedBL)-1)) and (blEnd < regionEnd):
+				if (pos == (len(overlappedBL) - 1)) and (blEnd < regionEnd):
 					if blEnd == regionEnd:
 						break
-					regionWoBL.append([ regionChromo, blEnd, regionEnd ])
+					regionWoBL.append((regionChromo, blEnd, regionEnd))
 
 		REGION = regionWoBL
 
 	# check if all chromosomes in the REGION in bigwig files
 	bigWig = pyBigWig.open(CTRLBW_NAMES[0])
 	regionFinal = []
-	for regionTuple in REGION:
-		chromo = regionTuple[0]
-		start = int(regionTuple[1])
-		end = int(regionTuple[2])
-
+	for chromo, start, end in REGION:
 		chromoLen = bigWig.chroms(chromo)
-		if chromoLen is None:
+
+		if chromoLen is None or chromoLen <= start:
 			continue
-		if end > chromoLen:
-			regionTuple[2] = chromoLen
-			if chromoLen <= start:
-				continue
-		regionFinal.append([chromo, start, end])
+
+		regionFinal.append((chromo, start, min(end, chromoLen)))
 	bigWig.close()
 
 	REGION = regionFinal

--- a/CRADLE/CallPeak/vari.py
+++ b/CRADLE/CallPeak/vari.py
@@ -16,6 +16,34 @@ def setGlobalVariables(args):
 	setDistance(args.d)
 	setStatTesting(args.stat)
 
+	return {
+		"ctrlbwNames": CTRLBW_NAMES,
+		"expbwNames": EXPBW_NAMES,
+		"ctrlbwNum": CTRLBW_NUM,
+		"expbwNum": EXPBW_NUM,
+		"sampleNum": SAMPLE_NUM,
+		"allZero": ALL_ZERO,
+		"nullStd": None,
+		"i_log2fc": I_LOG2FC,
+		"normCtrlbwNames": NORM_CTRLBW_NAMES,
+		"normExpbwNames": NORM_EXPBW_NAMES,
+		"outputDir": OUTPUT_DIR,
+		"region": REGION,
+		"fdr": FDR,
+		"theta": None,
+		"filterCutoffs": FILTER_CUTOFFS,
+		"filterCutoffsThetas": FILTER_CUTOFFS_THETAS,
+		"regionCutoff": None,
+		"adjFDR": None,
+		"binSize1": BINSIZE1,
+		"binSize2": BINSIZE2,
+		"shiftSize2": SHIFTSIZE2,
+		"numprocess": NUMPROCESS,
+		"distance": DISTANCE,
+		"peakLen": PEAKLEN,
+		"equalVar": EQUALVAR,
+	}
+
 def setInputFiles(ctrlbwFiles, expbwFiles):
 	global CTRLBW_NAMES
 	global EXPBW_NAMES
@@ -42,25 +70,24 @@ def setInputFiles(ctrlbwFiles, expbwFiles):
 
 	ALL_ZERO = [0] * SAMPLE_NUM
 
+
 def setNormalizedInputFiles(normCtrlbw, normExpbw):
 	global I_LOG2FC
 
 	if normCtrlbw is None or normExpbw is None:
 		I_LOG2FC = False
 		return
-	
+
 	I_LOG2FC = True
 	global NORM_CTRLBW_NAMES
 	global NORM_EXPBW_NAMES
-	
+
 	if  len(normCtrlbw) != CTRLBW_NUM or len(normExpbw) != EXPBW_NUM:
-		print("Error: The number of normalized observed bigwigs does not match with the number of input bigwigs. The number of bigwigs in -ctrlbw and -expbw should match with the nubmer of biwigs in -normCtrlbw and -normExpbw, respectively.")	
+		print("Error: The number of normalized observed bigwigs does not match with the number of input bigwigs. The number of bigwigs in -ctrlbw and -expbw should match with the nubmer of biwigs in -normCtrlbw and -normExpbw, respectively.")
 		sys.exit()
 
 	NORM_CTRLBW_NAMES = normCtrlbw
 	NORM_EXPBW_NAMES = normExpbw
-
-
 
 
 def setOutputDirectory(outputDir):
@@ -311,8 +338,6 @@ def setBinSize(binSize1, binSize2):
 		BINSIZE1 = int(binSize1)
 		BINSIZE2 = int(float(BINSIZE1) / 6)
 		SHIFTSIZE2 = BINSIZE2
-
-
 
 
 def setNumProcess(numProcess):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = CRADLE
-version = 0.29.0
+version = 0.30.0
 description = Correct Read Counts and Analysis of Differently Expressed Regions
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,6 @@ ext_modules = [
 		['CRADLE/CalculateCovariates/covariateUtils.pyx'],
 		extra_compile_args=["-fno-strict-aliasing"]),
 	Extension(
-		'CRADLE.CallPeak.calculateRC',
-		['CRADLE/CallPeak/calculateRC.pyx'],
-		extra_compile_args=["-fno-strict-aliasing"]),
-	Extension(
 		'CRADLE.correctbiasutils.cython',
 		['CRADLE/correctbiasutils/cython.pyx'],
 		extra_compile_args=["-fno-strict-aliasing"])


### PR DESCRIPTION
Speeds up call peaks a little, but brings the code much closer to idiomatic python.

* Makes calculateRC.pyx a regular python file. Nothing was gained from it being cython.
* Uses one multiprocessing pool instead of lots
* Combines variance and region cutoff calculations into one step -- the data from was one fed directly into the other anyway, this saves some multiprocessing round trip time.
* Simplifies REGION list as a numpy array.
* minimizes how often bigwigs are read