### PR TITLE
Fixes issue in callpeak setAnalysisRegion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [0.30.1]
+
+### Fixed
+
+- CallPeak bug when calcuating analysis regions using a blacklist
+
 ## [0.30.0]
 
 ### Fixed

--- a/CRADLE/CallPeak/vari.py
+++ b/CRADLE/CallPeak/vari.py
@@ -219,9 +219,9 @@ def setAnlaysisRegion(regionsFile, blacklistFile):
 			overlappedBL = overlappedBL[overlappedBL[:]["start"].argsort()]
 
 			currStart = regionStart
-			for pos in overlappedBL:
-				blStart = pos["start"]
-				blEnd = pos["end"]
+			for pos, blRegion in enumerate(overlappedBL):
+				blStart = blRegion["start"]
+				blEnd = blRegion["end"]
 
 				if blStart <= regionStart:
 					currStart = blEnd

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = CRADLE
-version = 0.30.0
+version = 0.30.1
 description = Correct Read Counts and Analysis of Differently Expressed Regions
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
In an older version of the code "pos" was an index into overlappedBL. A change was made so overlappedBL was iterated over directly and pos became a small numpy array. But it was still used as a number in one place!

So this change iterates over overlappedBL using enumerate so pos can be the number it was supposed to be and blRegion is the value at that index.